### PR TITLE
Backport to Qt4.8

### DIFF
--- a/src/xlsx/qtxlsx.pri
+++ b/src/xlsx/qtxlsx.pri
@@ -48,7 +48,10 @@ HEADERS += $$PWD/xlsxdocpropscore_p.h \
     $$PWD/xlsxchart_p.h \
     $$PWD/xlsxsimpleooxmlfile_p.h \
     $$PWD/xlsxcellformula.h \
-    $$PWD/xlsxcellformula_p.h
+    $$PWD/xlsxcellformula_p.h \
+    $$PWD/qzlibreader.h \
+    $$PWD/qzlibwriter.h
+
 
 SOURCES += $$PWD/xlsxdocpropscore.cpp \
     $$PWD/xlsxdocpropsapp.cpp \
@@ -80,5 +83,6 @@ SOURCES += $$PWD/xlsxdocpropscore.cpp \
     $$PWD/xlsxabstractooxmlfile.cpp \
     $$PWD/xlsxchart.cpp \
     $$PWD/xlsxsimpleooxmlfile.cpp \
-    $$PWD/xlsxcellformula.cpp
+    $$PWD/xlsxcellformula.cpp \
+    $$PWD/qzlib.cpp
 

--- a/src/xlsx/qzlib.cpp
+++ b/src/xlsx/qzlib.cpp
@@ -1,0 +1,1260 @@
+/****************************************************************************
+**
+** Copyright (C) 2013 Digia Plc and/or its subsidiary(-ies).
+** Contact: http://www.qt-project.org/legal
+**
+** This file is part of the QtGui module of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and Digia.  For licensing terms and
+** conditions see http://qt.digia.com/licensing.  For further information
+** use the contact form at http://qt.digia.com/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** In addition, as a special exception, Digia gives you certain additional
+** rights.  These rights are described in the Digia Qt LGPL Exception
+** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 3.0 as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU General Public License version 3.0 requirements will be
+** met: http://www.gnu.org/copyleft/gpl.html.
+**
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+#include <qglobal.h>
+
+
+#include "qzlibreader.h"
+#include "qzlibwriter.h"
+#include <qdatetime.h>
+#include <qplatformdefs.h>
+#include <qendian.h>
+#include <qdebug.h>
+#include <qdir.h>
+
+#include <zlib.h>
+
+#if defined(Q_OS_WIN)
+#  undef S_IFREG
+#  define S_IFREG 0100000
+#  ifndef S_IFDIR
+#    define S_IFDIR 0040000
+#  endif
+#  ifndef S_ISDIR
+#    define S_ISDIR(x) ((x) & S_IFDIR) > 0
+#  endif
+#  ifndef S_ISREG
+#    define S_ISREG(x) ((x) & 0170000) == S_IFREG
+#  endif
+#  define S_IFLNK 020000
+#  define S_ISLNK(x) ((x) & S_IFLNK) > 0
+#  ifndef S_IRUSR
+#    define S_IRUSR 0400
+#  endif
+#  ifndef S_IWUSR
+#    define S_IWUSR 0200
+#  endif
+#  ifndef S_IXUSR
+#    define S_IXUSR 0100
+#  endif
+#  define S_IRGRP 0040
+#  define S_IWGRP 0020
+#  define S_IXGRP 0010
+#  define S_IROTH 0004
+#  define S_IWOTH 0002
+#  define S_IXOTH 0001
+#endif
+
+#if 0
+#define ZDEBUG qDebug
+#else
+#define ZDEBUG if (0) qDebug
+#endif
+
+QT_BEGIN_NAMESPACE
+
+static inline uint readUInt(const uchar *data)
+{
+    return (data[0]) + (data[1]<<8) + (data[2]<<16) + (data[3]<<24);
+}
+
+static inline ushort readUShort(const uchar *data)
+{
+    return (data[0]) + (data[1]<<8);
+}
+
+static inline void writeUInt(uchar *data, uint i)
+{
+    data[0] = i & 0xff;
+    data[1] = (i>>8) & 0xff;
+    data[2] = (i>>16) & 0xff;
+    data[3] = (i>>24) & 0xff;
+}
+
+static inline void writeUShort(uchar *data, ushort i)
+{
+    data[0] = i & 0xff;
+    data[1] = (i>>8) & 0xff;
+}
+
+static inline void copyUInt(uchar *dest, const uchar *src)
+{
+    dest[0] = src[0];
+    dest[1] = src[1];
+    dest[2] = src[2];
+    dest[3] = src[3];
+}
+
+static inline void copyUShort(uchar *dest, const uchar *src)
+{
+    dest[0] = src[0];
+    dest[1] = src[1];
+}
+
+static void writeMSDosDate(uchar *dest, const QDateTime& dt)
+{
+    if (dt.isValid()) {
+        quint16 time =
+            (dt.time().hour() << 11)    // 5 bit hour
+            | (dt.time().minute() << 5)   // 6 bit minute
+            | (dt.time().second() >> 1);  // 5 bit double seconds
+
+        dest[0] = time & 0xff;
+        dest[1] = time >> 8;
+
+        quint16 date =
+            ((dt.date().year() - 1980) << 9) // 7 bit year 1980-based
+            | (dt.date().month() << 5)           // 4 bit month
+            | (dt.date().day());                 // 5 bit day
+
+        dest[2] = char(date);
+        dest[3] = char(date >> 8);
+    } else {
+        dest[0] = 0;
+        dest[1] = 0;
+        dest[2] = 0;
+        dest[3] = 0;
+    }
+}
+
+static quint32 permissionsToMode(QFile::Permissions perms)
+{
+    quint32 mode = 0;
+    if (perms & QFile::ReadOwner)
+        mode |= S_IRUSR;
+    if (perms & QFile::WriteOwner)
+        mode |= S_IWUSR;
+    if (perms & QFile::ExeOwner)
+        mode |= S_IXUSR;
+    if (perms & QFile::ReadUser)
+        mode |= S_IRUSR;
+    if (perms & QFile::WriteUser)
+        mode |= S_IWUSR;
+    if (perms & QFile::ExeUser)
+        mode |= S_IXUSR;
+    if (perms & QFile::ReadGroup)
+        mode |= S_IRGRP;
+    if (perms & QFile::WriteGroup)
+        mode |= S_IWGRP;
+    if (perms & QFile::ExeGroup)
+        mode |= S_IXGRP;
+    if (perms & QFile::ReadOther)
+        mode |= S_IROTH;
+    if (perms & QFile::WriteOther)
+        mode |= S_IWOTH;
+    if (perms & QFile::ExeOther)
+        mode |= S_IXOTH;
+    return mode;
+}
+
+static int inflate(Bytef *dest, ulong *destLen, const Bytef *source, ulong sourceLen)
+{
+    z_stream stream;
+    int err;
+
+    stream.next_in = (Bytef*)source;
+    stream.avail_in = (uInt)sourceLen;
+    if ((uLong)stream.avail_in != sourceLen)
+        return Z_BUF_ERROR;
+
+    stream.next_out = dest;
+    stream.avail_out = (uInt)*destLen;
+    if ((uLong)stream.avail_out != *destLen)
+        return Z_BUF_ERROR;
+
+    stream.zalloc = (alloc_func)0;
+    stream.zfree = (free_func)0;
+
+    err = inflateInit2(&stream, -MAX_WBITS);
+    if (err != Z_OK)
+        return err;
+
+    err = inflate(&stream, Z_FINISH);
+    if (err != Z_STREAM_END) {
+        inflateEnd(&stream);
+        if (err == Z_NEED_DICT || (err == Z_BUF_ERROR && stream.avail_in == 0))
+            return Z_DATA_ERROR;
+        return err;
+    }
+    *destLen = stream.total_out;
+
+    err = inflateEnd(&stream);
+    return err;
+}
+
+static int deflate (Bytef *dest, ulong *destLen, const Bytef *source, ulong sourceLen)
+{
+    z_stream stream;
+    int err;
+
+    stream.next_in = (Bytef*)source;
+    stream.avail_in = (uInt)sourceLen;
+    stream.next_out = dest;
+    stream.avail_out = (uInt)*destLen;
+    if ((uLong)stream.avail_out != *destLen) return Z_BUF_ERROR;
+
+    stream.zalloc = (alloc_func)0;
+    stream.zfree = (free_func)0;
+    stream.opaque = (voidpf)0;
+
+    err = deflateInit2(&stream, Z_DEFAULT_COMPRESSION, Z_DEFLATED, -MAX_WBITS, 8, Z_DEFAULT_STRATEGY);
+    if (err != Z_OK) return err;
+
+    err = deflate(&stream, Z_FINISH);
+    if (err != Z_STREAM_END) {
+        deflateEnd(&stream);
+        return err == Z_OK ? Z_BUF_ERROR : err;
+    }
+    *destLen = stream.total_out;
+
+    err = deflateEnd(&stream);
+    return err;
+}
+
+static QFile::Permissions modeToPermissions(quint32 mode)
+{
+    QFile::Permissions ret;
+    if (mode & S_IRUSR)
+        ret |= QFile::ReadOwner;
+    if (mode & S_IWUSR)
+        ret |= QFile::WriteOwner;
+    if (mode & S_IXUSR)
+        ret |= QFile::ExeOwner;
+    if (mode & S_IRUSR)
+        ret |= QFile::ReadUser;
+    if (mode & S_IWUSR)
+        ret |= QFile::WriteUser;
+    if (mode & S_IXUSR)
+        ret |= QFile::ExeUser;
+    if (mode & S_IRGRP)
+        ret |= QFile::ReadGroup;
+    if (mode & S_IWGRP)
+        ret |= QFile::WriteGroup;
+    if (mode & S_IXGRP)
+        ret |= QFile::ExeGroup;
+    if (mode & S_IROTH)
+        ret |= QFile::ReadOther;
+    if (mode & S_IWOTH)
+        ret |= QFile::WriteOther;
+    if (mode & S_IXOTH)
+        ret |= QFile::ExeOther;
+    return ret;
+}
+
+static QDateTime readMSDosDate(const uchar *src)
+{
+    uint dosDate = readUInt(src);
+    quint64 uDate;
+    uDate = (quint64)(dosDate >> 16);
+    uint tm_mday = (uDate & 0x1f);
+    uint tm_mon =  ((uDate & 0x1E0) >> 5);
+    uint tm_year = (((uDate & 0x0FE00) >> 9) + 1980);
+    uint tm_hour = ((dosDate & 0xF800) >> 11);
+    uint tm_min =  ((dosDate & 0x7E0) >> 5);
+    uint tm_sec =  ((dosDate & 0x1f) << 1);
+
+    return QDateTime(QDate(tm_year, tm_mon, tm_mday), QTime(tm_hour, tm_min, tm_sec));
+}
+
+struct LocalFileHeader
+{
+    uchar signature[4]; //  0x04034b50
+    uchar version_needed[2];
+    uchar general_purpose_bits[2];
+    uchar compression_method[2];
+    uchar last_mod_file[4];
+    uchar crc_32[4];
+    uchar compressed_size[4];
+    uchar uncompressed_size[4];
+    uchar file_name_length[2];
+    uchar extra_field_length[2];
+};
+
+struct DataDescriptor
+{
+    uchar crc_32[4];
+    uchar compressed_size[4];
+    uchar uncompressed_size[4];
+};
+
+struct CentralFileHeader
+{
+    uchar signature[4]; // 0x02014b50
+    uchar version_made[2];
+    uchar version_needed[2];
+    uchar general_purpose_bits[2];
+    uchar compression_method[2];
+    uchar last_mod_file[4];
+    uchar crc_32[4];
+    uchar compressed_size[4];
+    uchar uncompressed_size[4];
+    uchar file_name_length[2];
+    uchar extra_field_length[2];
+    uchar file_comment_length[2];
+    uchar disk_start[2];
+    uchar internal_file_attributes[2];
+    uchar external_file_attributes[4];
+    uchar offset_local_header[4];
+    LocalFileHeader toLocalHeader() const;
+};
+
+struct EndOfDirectory
+{
+    uchar signature[4]; // 0x06054b50
+    uchar this_disk[2];
+    uchar start_of_directory_disk[2];
+    uchar num_dir_entries_this_disk[2];
+    uchar num_dir_entries[2];
+    uchar directory_size[4];
+    uchar dir_start_offset[4];
+    uchar comment_length[2];
+};
+
+struct FileHeader
+{
+    CentralFileHeader h;
+    QByteArray file_name;
+    QByteArray extra_field;
+    QByteArray file_comment;
+};
+
+QZLibReader::FileInfo::FileInfo()
+    : isDir(false), isFile(false), isSymLink(false), crc32(0), size(0)
+{
+}
+
+QZLibReader::FileInfo::~FileInfo()
+{
+}
+
+QZLibReader::FileInfo::FileInfo(const FileInfo &other)
+{
+    operator=(other);
+}
+
+QZLibReader::FileInfo& QZLibReader::FileInfo::operator=(const FileInfo &other)
+{
+    filePath = other.filePath;
+    isDir = other.isDir;
+    isFile = other.isFile;
+    isSymLink = other.isSymLink;
+    permissions = other.permissions;
+    crc32 = other.crc32;
+    size = other.size;
+    lastModified = other.lastModified;
+    return *this;
+}
+
+bool QZLibReader::FileInfo::isValid() const
+{
+    return isDir || isFile || isSymLink;
+}
+
+class QZipPrivate
+{
+public:
+    QZipPrivate(QIODevice *device, bool ownDev)
+        : device(device), ownDevice(ownDev), dirtyFileTree(true), start_of_directory(0)
+    {
+    }
+
+    ~QZipPrivate()
+    {
+        if (ownDevice)
+            delete device;
+    }
+
+    void fillFileInfo(int index, QZLibReader::FileInfo &fileInfo) const;
+
+    QIODevice *device;
+    bool ownDevice;
+    bool dirtyFileTree;
+    QList<FileHeader> fileHeaders;
+    QByteArray comment;
+    uint start_of_directory;
+};
+
+void QZipPrivate::fillFileInfo(int index, QZLibReader::FileInfo &fileInfo) const
+{
+    FileHeader header = fileHeaders.at(index);
+    fileInfo.filePath = QString::fromLocal8Bit(header.file_name);
+    const quint32 mode = (qFromLittleEndian<quint32>(&header.h.external_file_attributes[0]) >> 16) & 0xFFFF;
+    fileInfo.isDir = S_ISDIR(mode);
+    fileInfo.isFile = S_ISREG(mode) || !mode;
+    fileInfo.isSymLink = S_ISLNK(mode);
+    fileInfo.permissions = modeToPermissions(mode);
+    fileInfo.crc32 = readUInt(header.h.crc_32);
+    fileInfo.size = readUInt(header.h.uncompressed_size);
+    fileInfo.lastModified = readMSDosDate(header.h.last_mod_file);
+}
+
+class QZLibReaderPrivate : public QZipPrivate
+{
+public:
+    QZLibReaderPrivate(QIODevice *device, bool ownDev)
+        : QZipPrivate(device, ownDev), status(QZLibReader::NoError)
+    {
+    }
+
+    void scanFiles();
+
+    QZLibReader::Status status;
+};
+
+class QZLibWriterPrivate : public QZipPrivate
+{
+public:
+    QZLibWriterPrivate(QIODevice *device, bool ownDev)
+        : QZipPrivate(device, ownDev),
+        status(QZLibWriter::NoError),
+        permissions(QFile::ReadOwner | QFile::WriteOwner),
+        compressionPolicy(QZLibWriter::AlwaysCompress)
+    {
+    }
+
+    QZLibWriter::Status status;
+    QFile::Permissions permissions;
+    QZLibWriter::CompressionPolicy compressionPolicy;
+
+    enum EntryType { Directory, File, Symlink };
+
+    void addEntry(EntryType type, const QString &fileName, const QByteArray &contents);
+};
+
+LocalFileHeader CentralFileHeader::toLocalHeader() const
+{
+    LocalFileHeader h;
+    writeUInt(h.signature, 0x04034b50);
+    copyUShort(h.version_needed, version_needed);
+    copyUShort(h.general_purpose_bits, general_purpose_bits);
+    copyUShort(h.compression_method, compression_method);
+    copyUInt(h.last_mod_file, last_mod_file);
+    copyUInt(h.crc_32, crc_32);
+    copyUInt(h.compressed_size, compressed_size);
+    copyUInt(h.uncompressed_size, uncompressed_size);
+    copyUShort(h.file_name_length, file_name_length);
+    copyUShort(h.extra_field_length, extra_field_length);
+    return h;
+}
+
+void QZLibReaderPrivate::scanFiles()
+{
+    if (!dirtyFileTree)
+        return;
+
+    if (! (device->isOpen() || device->open(QIODevice::ReadOnly))) {
+        status = QZLibReader::FileOpenError;
+        return;
+    }
+
+    if ((device->openMode() & QIODevice::ReadOnly) == 0) { // only read the index from readable files.
+        status = QZLibReader::FileReadError;
+        return;
+    }
+
+    dirtyFileTree = false;
+    uchar tmp[4];
+    device->read((char *)tmp, 4);
+    if (readUInt(tmp) != 0x04034b50) {
+        qWarning() << "QZip: not a zip file!";
+        return;
+    }
+
+    // find EndOfDirectory header
+    int i = 0;
+    int start_of_directory = -1;
+    int num_dir_entries = 0;
+    EndOfDirectory eod;
+    while (start_of_directory == -1) {
+        int pos = device->size() - sizeof(EndOfDirectory) - i;
+        if (pos < 0 || i > 65535) {
+            qWarning() << "QZip: EndOfDirectory not found";
+            return;
+        }
+
+        device->seek(pos);
+        device->read((char *)&eod, sizeof(EndOfDirectory));
+        if (readUInt(eod.signature) == 0x06054b50)
+            break;
+        ++i;
+    }
+
+    // have the eod
+    start_of_directory = readUInt(eod.dir_start_offset);
+    num_dir_entries = readUShort(eod.num_dir_entries);
+    ZDEBUG("start_of_directory at %d, num_dir_entries=%d", start_of_directory, num_dir_entries);
+    int comment_length = readUShort(eod.comment_length);
+    if (comment_length != i)
+        qWarning() << "QZip: failed to parse zip file.";
+    comment = device->read(qMin(comment_length, i));
+
+
+    device->seek(start_of_directory);
+    for (i = 0; i < num_dir_entries; ++i) {
+        FileHeader header;
+        int read = device->read((char *) &header.h, sizeof(CentralFileHeader));
+        if (read < (int)sizeof(CentralFileHeader)) {
+            qWarning() << "QZip: Failed to read complete header, index may be incomplete";
+            break;
+        }
+        if (readUInt(header.h.signature) != 0x02014b50) {
+            qWarning() << "QZip: invalid header signature, index may be incomplete";
+            break;
+        }
+
+        int l = readUShort(header.h.file_name_length);
+        header.file_name = device->read(l);
+        if (header.file_name.length() != l) {
+            qWarning() << "QZip: Failed to read filename from zip index, index may be incomplete";
+            break;
+        }
+        l = readUShort(header.h.extra_field_length);
+        header.extra_field = device->read(l);
+        if (header.extra_field.length() != l) {
+            qWarning() << "QZip: Failed to read extra field in zip file, skipping file, index may be incomplete";
+            break;
+        }
+        l = readUShort(header.h.file_comment_length);
+        header.file_comment = device->read(l);
+        if (header.file_comment.length() != l) {
+            qWarning() << "QZip: Failed to read read file comment, index may be incomplete";
+            break;
+        }
+
+        ZDEBUG("found file '%s'", header.file_name.data());
+        fileHeaders.append(header);
+    }
+}
+
+void QZLibWriterPrivate::addEntry(EntryType type, const QString &fileName, const QByteArray &contents/*, QFile::Permissions permissions, QZip::Method m*/)
+{
+#ifndef NDEBUG
+    static const char *entryTypes[] = {
+        "directory",
+        "file     ",
+        "symlink  " };
+    ZDEBUG() << "adding" << entryTypes[type] <<":" << fileName.toUtf8().data() << (type == 2 ? QByteArray(" -> " + contents).constData() : "");
+#endif
+
+    if (! (device->isOpen() || device->open(QIODevice::WriteOnly))) {
+        status = QZLibWriter::FileOpenError;
+        return;
+    }
+    device->seek(start_of_directory);
+
+    // don't compress small files
+    QZLibWriter::CompressionPolicy compression = compressionPolicy;
+    if (compressionPolicy == QZLibWriter::AutoCompress) {
+        if (contents.length() < 64)
+            compression = QZLibWriter::NeverCompress;
+        else
+            compression = QZLibWriter::AlwaysCompress;
+    }
+
+    FileHeader header;
+    memset(&header.h, 0, sizeof(CentralFileHeader));
+    writeUInt(header.h.signature, 0x02014b50);
+
+    writeUShort(header.h.version_needed, 0x14);
+    writeUInt(header.h.uncompressed_size, contents.length());
+    writeMSDosDate(header.h.last_mod_file, QDateTime::currentDateTime());
+    QByteArray data = contents;
+    if (compression == QZLibWriter::AlwaysCompress) {
+        writeUShort(header.h.compression_method, 8);
+
+       ulong len = contents.length();
+        // shamelessly copied form zlib
+        len += (len >> 12) + (len >> 14) + 11;
+        int res;
+        do {
+            data.resize(len);
+            res = deflate((uchar*)data.data(), &len, (const uchar*)contents.constData(), contents.length());
+
+            switch (res) {
+            case Z_OK:
+                data.resize(len);
+                break;
+            case Z_MEM_ERROR:
+                qWarning("QZip: Z_MEM_ERROR: Not enough memory to compress file, skipping");
+                data.resize(0);
+                break;
+            case Z_BUF_ERROR:
+                len *= 2;
+                break;
+            }
+        } while (res == Z_BUF_ERROR);
+    }
+// TODO add a check if data.length() > contents.length().  Then try to store the original and revert the compression method to be uncompressed
+    writeUInt(header.h.compressed_size, data.length());
+    uint crc_32 = ::crc32(0, 0, 0);
+    crc_32 = ::crc32(crc_32, (const uchar *)contents.constData(), contents.length());
+    writeUInt(header.h.crc_32, crc_32);
+
+    header.file_name = fileName.toLocal8Bit();
+    if (header.file_name.size() > 0xffff) {
+        qWarning("QZip: Filename too long, chopping it to 65535 characters");
+        header.file_name = header.file_name.left(0xffff);
+    }
+    writeUShort(header.h.file_name_length, header.file_name.length());
+    //h.extra_field_length[2];
+
+    writeUShort(header.h.version_made, 3 << 8);
+    //uchar internal_file_attributes[2];
+    //uchar external_file_attributes[4];
+    quint32 mode = permissionsToMode(permissions);
+    switch (type) {
+        case File: mode |= S_IFREG; break;
+        case Directory: mode |= S_IFDIR; break;
+        case Symlink: mode |= S_IFLNK; break;
+    }
+    writeUInt(header.h.external_file_attributes, mode << 16);
+    writeUInt(header.h.offset_local_header, start_of_directory);
+
+
+    fileHeaders.append(header);
+
+    LocalFileHeader h = header.h.toLocalHeader();
+    device->write((const char *)&h, sizeof(LocalFileHeader));
+    device->write(header.file_name);
+    device->write(data);
+    start_of_directory = device->pos();
+    dirtyFileTree = true;
+}
+
+//////////////////////////////  Reader
+
+/*!
+    \class QZipReader::FileInfo
+    \internal
+    Represents one entry in the zip table of contents.
+*/
+
+/*!
+    \variable FileInfo::filePath
+    The full filepath inside the archive.
+*/
+
+/*!
+    \variable FileInfo::isDir
+    A boolean type indicating if the entry is a directory.
+*/
+
+/*!
+    \variable FileInfo::isFile
+    A boolean type, if it is one this entry is a file.
+*/
+
+/*!
+    \variable FileInfo::isSymLink
+    A boolean type, if it is one this entry is symbolic link.
+*/
+
+/*!
+    \variable FileInfo::permissions
+    A list of flags for the permissions of this entry.
+*/
+
+/*!
+    \variable FileInfo::crc32
+    The calculated checksum as a crc32 type.
+*/
+
+/*!
+    \variable FileInfo::size
+    The total size of the unpacked content.
+*/
+
+/*!
+    \variable FileInfo::d
+    \internal
+    private pointer.
+*/
+
+/*!
+    \class QZipReader
+    \internal
+    \since 4.5
+
+    \brief the QZipReader class provides a way to inspect the contents of a zip
+    archive and extract individual files from it.
+
+    QZipReader can be used to read a zip archive either from a file or from any
+    device. An in-memory QBuffer for instance.  The reader can be used to read
+    which files are in the archive using fileInfoList() and entryInfoAt() but
+    also to extract individual files using fileData() or even to extract all
+    files in the archive using extractAll()
+*/
+
+/*!
+    Create a new zip archive that operates on the \a fileName.  The file will be
+    opened with the \a mode.
+*/
+QZLibReader::QZLibReader(const QString &archive, QIODevice::OpenMode mode)
+{
+    QScopedPointer<QFile> f(new QFile(archive));
+    f->open(mode);
+    QZLibReader::Status status;
+    if (f->error() == QFile::NoError)
+        status = NoError;
+    else {
+        if (f->error() == QFile::ReadError)
+            status = FileReadError;
+        else if (f->error() == QFile::OpenError)
+            status = FileOpenError;
+        else if (f->error() == QFile::PermissionsError)
+            status = FilePermissionsError;
+        else
+            status = FileError;
+    }
+
+    d = new QZLibReaderPrivate(f.data(), /*ownDevice=*/true);
+    f.take();
+    d->status = status;
+}
+
+/*!
+    Create a new zip archive that operates on the archive found in \a device.
+    You have to open the device previous to calling the constructor and only a
+    device that is readable will be scanned for zip filecontent.
+ */
+QZLibReader::QZLibReader(QIODevice *device)
+    : d(new QZLibReaderPrivate(device, /*ownDevice=*/false))
+{
+    Q_ASSERT(device);
+}
+
+/*!
+    Desctructor
+*/
+QZLibReader::~QZLibReader()
+{
+    close();
+    delete d;
+}
+
+/*!
+    Returns device used for reading zip archive.
+*/
+QIODevice* QZLibReader::device() const
+{
+    return d->device;
+}
+
+/*!
+    Returns true if the user can read the file; otherwise returns false.
+*/
+bool QZLibReader::isReadable() const
+{
+    return d->device->isReadable();
+}
+
+/*!
+    Returns true if the file exists; otherwise returns false.
+*/
+bool QZLibReader::exists() const
+{
+    QFile *f = qobject_cast<QFile*> (d->device);
+    if (f == 0)
+        return true;
+    return f->exists();
+}
+
+/*!
+    Returns the list of files the archive contains.
+*/
+QList<QZLibReader::FileInfo> QZLibReader::fileInfoList() const
+{
+    d->scanFiles();
+    QList<QZLibReader::FileInfo> files;
+    for (int i = 0; i < d->fileHeaders.size(); ++i) {
+        QZLibReader::FileInfo fi;
+        d->fillFileInfo(i, fi);
+        files.append(fi);
+    }
+    return files;
+
+}
+
+/*!
+    Return the number of items in the zip archive.
+*/
+int QZLibReader::count() const
+{
+    d->scanFiles();
+    return d->fileHeaders.count();
+}
+
+/*!
+    Returns a FileInfo of an entry in the zipfile.
+    The \a index is the index into the directory listing of the zipfile.
+    Returns an invalid FileInfo if \a index is out of boundaries.
+
+    \sa fileInfoList()
+*/
+QZLibReader::FileInfo QZLibReader::entryInfoAt(int index) const
+{
+    d->scanFiles();
+    QZLibReader::FileInfo fi;
+    if (index >= 0 && index < d->fileHeaders.count())
+        d->fillFileInfo(index, fi);
+    return fi;
+}
+
+/*!
+    Fetch the file contents from the zip archive and return the uncompressed bytes.
+*/
+QByteArray QZLibReader::fileData(const QString &fileName) const
+{
+    d->scanFiles();
+    int i;
+    for (i = 0; i < d->fileHeaders.size(); ++i) {
+        if (QString::fromLocal8Bit(d->fileHeaders.at(i).file_name) == fileName)
+            break;
+    }
+    if (i == d->fileHeaders.size())
+        return QByteArray();
+
+    FileHeader header = d->fileHeaders.at(i);
+
+    int compressed_size = readUInt(header.h.compressed_size);
+    int uncompressed_size = readUInt(header.h.uncompressed_size);
+    int start = readUInt(header.h.offset_local_header);
+    //qDebug("uncompressing file %d: local header at %d", i, start);
+
+    d->device->seek(start);
+    LocalFileHeader lh;
+    d->device->read((char *)&lh, sizeof(LocalFileHeader));
+    uint skip = readUShort(lh.file_name_length) + readUShort(lh.extra_field_length);
+    d->device->seek(d->device->pos() + skip);
+
+    int compression_method = readUShort(lh.compression_method);
+    //qDebug("file=%s: compressed_size=%d, uncompressed_size=%d", fileName.toLocal8Bit().data(), compressed_size, uncompressed_size);
+
+    //qDebug("file at %lld", d->device->pos());
+    QByteArray compressed = d->device->read(compressed_size);
+    if (compression_method == 0) {
+        // no compression
+        compressed.truncate(uncompressed_size);
+        return compressed;
+    } else if (compression_method == 8) {
+        // Deflate
+        //qDebug("compressed=%d", compressed.size());
+        compressed.truncate(compressed_size);
+        QByteArray baunzip;
+        ulong len = qMax(uncompressed_size,  1);
+        int res;
+        do {
+            baunzip.resize(len);
+            res = inflate((uchar*)baunzip.data(), &len,
+                          (uchar*)compressed.constData(), compressed_size);
+
+            switch (res) {
+            case Z_OK:
+                if ((int)len != baunzip.size())
+                    baunzip.resize(len);
+                break;
+            case Z_MEM_ERROR:
+                qWarning("QZip: Z_MEM_ERROR: Not enough memory");
+                break;
+            case Z_BUF_ERROR:
+                len *= 2;
+                break;
+            case Z_DATA_ERROR:
+                qWarning("QZip: Z_DATA_ERROR: Input data is corrupted");
+                break;
+            }
+        } while (res == Z_BUF_ERROR);
+        return baunzip;
+    }
+    qWarning() << "QZip: Unknown compression method";
+    return QByteArray();
+}
+
+/*!
+    Extracts the full contents of the zip file into \a destinationDir on
+    the local filesystem.
+    In case writing or linking a file fails, the extraction will be aborted.
+*/
+bool QZLibReader::extractAll(const QString &destinationDir) const
+{
+    QDir baseDir(destinationDir);
+
+    // create directories first
+    QList<FileInfo> allFiles = fileInfoList();
+    foreach (FileInfo fi, allFiles) {
+        const QString absPath = destinationDir + QDir::separator() + fi.filePath;
+        if (fi.isDir) {
+            if (!baseDir.mkpath(fi.filePath))
+                return false;
+            if (!QFile::setPermissions(absPath, fi.permissions))
+                return false;
+        }
+    }
+
+    // set up symlinks
+    foreach (FileInfo fi, allFiles) {
+        const QString absPath = destinationDir + QDir::separator() + fi.filePath;
+        if (fi.isSymLink) {
+            QString destination = QFile::decodeName(fileData(fi.filePath));
+            if (destination.isEmpty())
+                return false;
+            QFileInfo linkFi(absPath);
+            if (!QFile::exists(linkFi.absolutePath()))
+                QDir::root().mkpath(linkFi.absolutePath());
+            if (!QFile::link(destination, absPath))
+                return false;
+            /* cannot change permission of links
+            if (!QFile::setPermissions(absPath, fi.permissions))
+                return false;
+            */
+        }
+    }
+
+    foreach (FileInfo fi, allFiles) {
+        const QString absPath = destinationDir + QDir::separator() + fi.filePath;
+        if (fi.isFile) {
+            QFile f(absPath);
+            if (!f.open(QIODevice::WriteOnly))
+                return false;
+            f.write(fileData(fi.filePath));
+            f.setPermissions(fi.permissions);
+            f.close();
+        }
+    }
+
+    return true;
+}
+
+/*!
+    \enum QZipReader::Status
+
+    The following status values are possible:
+
+    \value NoError  No error occurred.
+    \value FileReadError    An error occurred when reading from the file.
+    \value FileOpenError    The file could not be opened.
+    \value FilePermissionsError The file could not be accessed.
+    \value FileError        Another file error occurred.
+*/
+
+/*!
+    Returns a status code indicating the first error that was met by QZipReader,
+    or QZipReader::NoError if no error occurred.
+*/
+QZLibReader::Status QZLibReader::status() const
+{
+    return d->status;
+}
+
+/*!
+    Close the zip file.
+*/
+void QZLibReader::close()
+{
+    d->device->close();
+}
+
+////////////////////////////// Writer
+
+/*!
+    \class QZipWriter
+    \internal
+    \since 4.5
+
+    \brief the QZipWriter class provides a way to create a new zip archive.
+
+    QZipWriter can be used to create a zip archive containing any number of files
+    and directories. The files in the archive will be compressed in a way that is
+    compatible with common zip reader applications.
+*/
+
+
+/*!
+    Create a new zip archive that operates on the \a archive filename.  The file will
+    be opened with the \a mode.
+    \sa isValid()
+*/
+QZLibWriter::QZLibWriter(const QString &fileName, QIODevice::OpenMode mode)
+{
+    QScopedPointer<QFile> f(new QFile(fileName));
+    f->open(mode);
+    QZLibWriter::Status status;
+    if (f->error() == QFile::NoError)
+        status = QZLibWriter::NoError;
+    else {
+        if (f->error() == QFile::WriteError)
+            status = QZLibWriter::FileWriteError;
+        else if (f->error() == QFile::OpenError)
+            status = QZLibWriter::FileOpenError;
+        else if (f->error() == QFile::PermissionsError)
+            status = QZLibWriter::FilePermissionsError;
+        else
+            status = QZLibWriter::FileError;
+    }
+
+    d = new QZLibWriterPrivate(f.data(), /*ownDevice=*/true);
+    f.take();
+    d->status = status;
+}
+
+/*!
+    Create a new zip archive that operates on the archive found in \a device.
+    You have to open the device previous to calling the constructor and
+    only a device that is readable will be scanned for zip filecontent.
+ */
+QZLibWriter::QZLibWriter(QIODevice *device)
+    : d(new QZLibWriterPrivate(device, /*ownDevice=*/false))
+{
+    Q_ASSERT(device);
+}
+
+QZLibWriter::~QZLibWriter()
+{
+    close();
+    delete d;
+}
+
+/*!
+    Returns device used for writing zip archive.
+*/
+QIODevice* QZLibWriter::device() const
+{
+    return d->device;
+}
+
+/*!
+    Returns true if the user can write to the archive; otherwise returns false.
+*/
+bool QZLibWriter::isWritable() const
+{
+    return d->device->isWritable();
+}
+
+/*!
+    Returns true if the file exists; otherwise returns false.
+*/
+bool QZLibWriter::exists() const
+{
+    QFile *f = qobject_cast<QFile*> (d->device);
+    if (f == 0)
+        return true;
+    return f->exists();
+}
+
+/*!
+    \enum QZipWriter::Status
+
+    The following status values are possible:
+
+    \value NoError  No error occurred.
+    \value FileWriteError    An error occurred when writing to the device.
+    \value FileOpenError    The file could not be opened.
+    \value FilePermissionsError The file could not be accessed.
+    \value FileError        Another file error occurred.
+*/
+
+/*!
+    Returns a status code indicating the first error that was met by QZipWriter,
+    or QZipWriter::NoError if no error occurred.
+*/
+QZLibWriter::Status QZLibWriter::status() const
+{
+    return d->status;
+}
+
+/*!
+    \enum QZipWriter::CompressionPolicy
+
+    \value AlwaysCompress   A file that is added is compressed.
+    \value NeverCompress    A file that is added will be stored without changes.
+    \value AutoCompress     A file that is added will be compressed only if that will give a smaller file.
+*/
+
+/*!
+     Sets the policy for compressing newly added files to the new \a policy.
+
+    \note the default policy is AlwaysCompress
+
+    \sa compressionPolicy()
+    \sa addFile()
+*/
+void QZLibWriter::setCompressionPolicy(CompressionPolicy policy)
+{
+    d->compressionPolicy = policy;
+}
+
+/*!
+     Returns the currently set compression policy.
+    \sa setCompressionPolicy()
+    \sa addFile()
+*/
+QZLibWriter::CompressionPolicy QZLibWriter::compressionPolicy() const
+{
+    return d->compressionPolicy;
+}
+
+/*!
+    Sets the permissions that will be used for newly added files.
+
+    \note the default permissions are QFile::ReadOwner | QFile::WriteOwner.
+
+    \sa creationPermissions()
+    \sa addFile()
+*/
+void QZLibWriter::setCreationPermissions(QFile::Permissions permissions)
+{
+    d->permissions = permissions;
+}
+
+/*!
+     Returns the currently set creation permissions.
+
+    \sa setCreationPermissions()
+    \sa addFile()
+*/
+QFile::Permissions QZLibWriter::creationPermissions() const
+{
+    return d->permissions;
+}
+
+/*!
+    Add a file to the archive with \a data as the file contents.
+    The file will be stored in the archive using the \a fileName which
+    includes the full path in the archive.
+
+    The new file will get the file permissions based on the current
+    creationPermissions and it will be compressed using the zip compression
+    based on the current compression policy.
+
+    \sa setCreationPermissions()
+    \sa setCompressionPolicy()
+*/
+void QZLibWriter::addFile(const QString &fileName, const QByteArray &data)
+{
+    d->addEntry(QZLibWriterPrivate::File, QDir::fromNativeSeparators(fileName), data);
+}
+
+/*!
+    Add a file to the archive with \a device as the source of the contents.
+    The contents returned from QIODevice::readAll() will be used as the
+    filedata.
+    The file will be stored in the archive using the \a fileName which
+    includes the full path in the archive.
+*/
+void QZLibWriter::addFile(const QString &fileName, QIODevice *device)
+{
+    Q_ASSERT(device);
+    QIODevice::OpenMode mode = device->openMode();
+    bool opened = false;
+    if ((mode & QIODevice::ReadOnly) == 0) {
+        opened = true;
+        if (! device->open(QIODevice::ReadOnly)) {
+            d->status = FileOpenError;
+            return;
+        }
+    }
+    d->addEntry(QZLibWriterPrivate::File, QDir::fromNativeSeparators(fileName), device->readAll());
+    if (opened)
+        device->close();
+}
+
+/*!
+    Create a new directory in the archive with the specified \a dirName and
+    the \a permissions;
+*/
+void QZLibWriter::addDirectory(const QString &dirName)
+{
+    QString name(QDir::fromNativeSeparators(dirName));
+    // separator is mandatory
+    if (!name.endsWith(QLatin1Char('/')))
+        name.append(QLatin1Char('/'));
+    d->addEntry(QZLibWriterPrivate::Directory, name, QByteArray());
+}
+
+/*!
+    Create a new symbolic link in the archive with the specified \a dirName
+    and the \a permissions;
+    A symbolic link contains the destination (relative) path and name.
+*/
+void QZLibWriter::addSymLink(const QString &fileName, const QString &destination)
+{
+    d->addEntry(QZLibWriterPrivate::Symlink, QDir::fromNativeSeparators(fileName), QFile::encodeName(destination));
+}
+
+/*!
+   Closes the zip file.
+*/
+void QZLibWriter::close()
+{
+    if (!(d->device->openMode() & QIODevice::WriteOnly)) {
+        d->device->close();
+        return;
+    }
+
+    //qDebug("QZip::close writing directory, %d entries", d->fileHeaders.size());
+    d->device->seek(d->start_of_directory);
+    // write new directory
+    for (int i = 0; i < d->fileHeaders.size(); ++i) {
+        const FileHeader &header = d->fileHeaders.at(i);
+        d->device->write((const char *)&header.h, sizeof(CentralFileHeader));
+        d->device->write(header.file_name);
+        d->device->write(header.extra_field);
+        d->device->write(header.file_comment);
+    }
+    int dir_size = d->device->pos() - d->start_of_directory;
+    // write end of directory
+    EndOfDirectory eod;
+    memset(&eod, 0, sizeof(EndOfDirectory));
+    writeUInt(eod.signature, 0x06054b50);
+    //uchar this_disk[2];
+    //uchar start_of_directory_disk[2];
+    writeUShort(eod.num_dir_entries_this_disk, d->fileHeaders.size());
+    writeUShort(eod.num_dir_entries, d->fileHeaders.size());
+    writeUInt(eod.directory_size, dir_size);
+    writeUInt(eod.dir_start_offset, d->start_of_directory);
+    writeUShort(eod.comment_length, d->comment.length());
+
+    d->device->write((const char *)&eod, sizeof(EndOfDirectory));
+    d->device->write(d->comment);
+    d->device->close();
+}
+
+QT_END_NAMESPACE
+

--- a/src/xlsx/qzlibreader.h
+++ b/src/xlsx/qzlibreader.h
@@ -1,0 +1,122 @@
+/****************************************************************************
+**
+** Copyright (C) 2013 Digia Plc and/or its subsidiary(-ies).
+** Contact: http://www.qt-project.org/legal
+**
+** This file is part of the QtGui module of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and Digia.  For licensing terms and
+** conditions see http://qt.digia.com/licensing.  For further information
+** use the contact form at http://qt.digia.com/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** In addition, as a special exception, Digia gives you certain additional
+** rights.  These rights are described in the Digia Qt LGPL Exception
+** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 3.0 as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU General Public License version 3.0 requirements will be
+** met: http://www.gnu.org/copyleft/gpl.html.
+**
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef QZLIBREADER_H
+#define QZLIBREADER_H
+
+
+//
+//  W A R N I N G
+//  -------------
+//
+// This file is not part of the Qt API.  It exists for the convenience
+// of the QZipReader class.  This header file may change from
+// version to version without notice, or even be removed.
+//
+// We mean it.
+//
+
+#include <QtCore/qdatetime.h>
+#include <QtCore/qfile.h>
+#include <QtCore/qstring.h>
+
+QT_BEGIN_NAMESPACE
+
+class QZLibReaderPrivate;
+
+class Q_GUI_EXPORT QZLibReader
+{
+public:
+    QZLibReader(const QString &fileName, QIODevice::OpenMode mode = QIODevice::ReadOnly );
+
+    explicit QZLibReader(QIODevice *device);
+    ~QZLibReader();
+
+    QIODevice* device() const;
+
+    bool isReadable() const;
+    bool exists() const;
+
+    struct Q_GUI_EXPORT FileInfo
+    {
+        FileInfo();
+        FileInfo(const FileInfo &other);
+        ~FileInfo();
+        FileInfo &operator=(const FileInfo &other);
+        bool isValid() const;
+        QString filePath;
+        uint isDir : 1;
+        uint isFile : 1;
+        uint isSymLink : 1;
+        QFile::Permissions permissions;
+        uint crc32;
+        qint64 size;
+        QDateTime lastModified;
+        void *d;
+    };
+
+    QList<FileInfo> fileInfoList() const;
+    int count() const;
+
+    FileInfo entryInfoAt(int index) const;
+    QByteArray fileData(const QString &fileName) const;
+    bool extractAll(const QString &destinationDir) const;
+
+    enum Status {
+        NoError,
+        FileReadError,
+        FileOpenError,
+        FilePermissionsError,
+        FileError
+    };
+
+    Status status() const;
+
+    void close();
+
+private:
+    QZLibReaderPrivate *d;
+    Q_DISABLE_COPY(QZLibReader)
+};
+
+QT_END_NAMESPACE
+
+#endif // QZLIBREADER_H

--- a/src/xlsx/qzlibwriter.h
+++ b/src/xlsx/qzlibwriter.h
@@ -1,0 +1,116 @@
+/****************************************************************************
+**
+** Copyright (C) 2013 Digia Plc and/or its subsidiary(-ies).
+** Contact: http://www.qt-project.org/legal
+**
+** This file is part of the QtGui module of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and Digia.  For licensing terms and
+** conditions see http://qt.digia.com/licensing.  For further information
+** use the contact form at http://qt.digia.com/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** In addition, as a special exception, Digia gives you certain additional
+** rights.  These rights are described in the Digia Qt LGPL Exception
+** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 3.0 as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU General Public License version 3.0 requirements will be
+** met: http://www.gnu.org/copyleft/gpl.html.
+**
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+#ifndef QZIPWRITER_H
+#define QZIPWRITER_H
+#ifndef QT_NO_TEXTODFWRITER
+
+//
+//  W A R N I N G
+//  -------------
+//
+// This file is not part of the Qt API.  It exists for the convenience
+// of the QZipWriter class.  This header file may change from
+// version to version without notice, or even be removed.
+//
+// We mean it.
+//
+
+#include <QtCore/qstring.h>
+#include <QtCore/qfile.h>
+
+QT_BEGIN_NAMESPACE
+
+class QZLibWriterPrivate;
+
+
+class Q_GUI_EXPORT QZLibWriter
+{
+public:
+    QZLibWriter(const QString &fileName, QIODevice::OpenMode mode = (QIODevice::WriteOnly | QIODevice::Truncate) );
+
+    explicit QZLibWriter(QIODevice *device);
+    ~QZLibWriter();
+
+    QIODevice* device() const;
+
+    bool isWritable() const;
+    bool exists() const;
+
+    enum Status {
+        NoError,
+        FileWriteError,
+        FileOpenError,
+        FilePermissionsError,
+        FileError
+    };
+
+    Status status() const;
+
+    enum CompressionPolicy {
+        AlwaysCompress,
+        NeverCompress,
+        AutoCompress
+    };
+
+    void setCompressionPolicy(CompressionPolicy policy);
+    CompressionPolicy compressionPolicy() const;
+
+    void setCreationPermissions(QFile::Permissions permissions);
+    QFile::Permissions creationPermissions() const;
+
+    void addFile(const QString &fileName, const QByteArray &data);
+
+    void addFile(const QString &fileName, QIODevice *device);
+
+    void addDirectory(const QString &dirName);
+
+    void addSymLink(const QString &fileName, const QString &destination);
+
+    void close();
+private:
+    QZLibWriterPrivate *d;
+    Q_DISABLE_COPY(QZLibWriter)
+};
+
+QT_END_NAMESPACE
+
+#endif // QT_NO_TEXTODFWRITER
+#endif // QZIPWRITER_H

--- a/src/xlsx/xlsxcellreference.cpp
+++ b/src/xlsx/xlsxcellreference.cpp
@@ -25,7 +25,11 @@
 #include "xlsxcellreference.h"
 #include <QStringList>
 #include <QMap>
-#include <QRegularExpression>
+#include <QtDebug>
+
+#if QT_VERSION >= 0x050000
+  #include <QRegularExpression>
+#endif
 
 QT_BEGIN_NAMESPACE_XLSX
 
@@ -118,6 +122,7 @@ CellReference::CellReference(const char *cell)
 
 void CellReference::init(const QString &cell_str)
 {
+#if QT_VERSION >= 0x050000 //TODO !!!
     static QRegularExpression re(QStringLiteral("^\\$?([A-Z]{1,3})\\$?(\\d+)$"));
     QRegularExpressionMatch match = re.match(cell_str);
     if (match.hasMatch()) {
@@ -126,6 +131,14 @@ void CellReference::init(const QString &cell_str)
         _row = row_str.toInt();
         _column = col_from_name(col_str);
     }
+#else
+  if(cell_str.length() >= 2)
+  {
+    _row = cell_str.mid(1).toInt();
+    _column = cell_str.at(0).toAscii() - QChar('A').toAscii() + 1;
+  }
+#endif
+  //qDebug() << cell_str << _row << _column;
 }
 
 /*!

--- a/src/xlsx/xlsxchart.cpp
+++ b/src/xlsx/xlsxchart.cpp
@@ -33,6 +33,7 @@
 #include <QXmlStreamWriter>
 #include <QDebug>
 
+
 QT_BEGIN_NAMESPACE_XLSX
 
 ChartPrivate::ChartPrivate(Chart *q, Chart::CreateFlag flag)

--- a/src/xlsx/xlsxcolor.cpp
+++ b/src/xlsx/xlsxcolor.cpp
@@ -188,7 +188,7 @@ QDebug operator<<(QDebug dbg, const XlsxColor &c)
     else if (c.isIndexedColor())
         dbg.nospace() << "XlsxColor(indexed," << c.indexedColor() << ")";
     else if (c.isThemeColor())
-        dbg.nospace() << "XlsxColor(theme," << c.themeColor().join(QLatin1Char(':')) << ")";
+        dbg.nospace() << "XlsxColor(theme," << c.themeColor().join(QChar(':')) << ")";
 
     return dbg.space();
 }

--- a/src/xlsx/xlsxconditionalformatting.cpp
+++ b/src/xlsx/xlsxconditionalformatting.cpp
@@ -660,7 +660,7 @@ bool ConditionalFormatting::saveToXml(QXmlStreamWriter &writer) const
     QStringList sqref;
     foreach (CellRange range, ranges())
         sqref.append(range.toString());
-    writer.writeAttribute(QStringLiteral("sqref"), sqref.join(QLatin1Char(' ')));
+    writer.writeAttribute(QStringLiteral("sqref"), sqref.join(QChar(' ')));
 
     for (int i=0; i<d->cfRules.size(); ++i) {
         const QSharedPointer<XlsxCfRuleData> &rule = d->cfRules[i];

--- a/src/xlsx/xlsxdatavalidation.cpp
+++ b/src/xlsx/xlsxdatavalidation.cpp
@@ -31,6 +31,7 @@
 #include <QXmlStreamReader>
 #include <QXmlStreamWriter>
 
+
 QT_BEGIN_NAMESPACE_XLSX
 
 DataValidationPrivate::DataValidationPrivate()
@@ -444,7 +445,7 @@ bool DataValidation::saveToXml(QXmlStreamWriter &writer) const
     QStringList sqref;
     foreach (CellRange range, ranges())
         sqref.append(range.toString());
-    writer.writeAttribute(QStringLiteral("sqref"), sqref.join(QLatin1Char(' ')));
+    writer.writeAttribute(QStringLiteral("sqref"), sqref.join(QChar(' ')));
 
     if (!formula1().isEmpty())
         writer.writeTextElement(QStringLiteral("formula1"), formula1());

--- a/src/xlsx/xlsxdocument.h
+++ b/src/xlsx/xlsxdocument.h
@@ -34,7 +34,9 @@
 class QIODevice;
 class QImage;
 
-QT_BEGIN_NAMESPACE_XLSX
+//QT_BEGIN_NAMESPACE_XLSX
+namespace QXlsx {
+
 
 class Workbook;
 class Cell;
@@ -128,6 +130,6 @@ private:
     DocumentPrivate * const d_ptr;
 };
 
-QT_END_NAMESPACE_XLSX
+} //QT_END_NAMESPACE_XLSX
 
 #endif // QXLSX_XLSXDOCUMENT_H

--- a/src/xlsx/xlsxdrawinganchor.cpp
+++ b/src/xlsx/xlsxdrawinganchor.cpp
@@ -35,6 +35,7 @@
 #include <QBuffer>
 #include <QDir>
 
+
 namespace QXlsx {
 
 /*

--- a/src/xlsx/xlsxdrawinganchor_p.h
+++ b/src/xlsx/xlsxdrawinganchor_p.h
@@ -32,6 +32,7 @@
 #include <QSize>
 #include <QString>
 #include <QSharedPointer>
+#include <QImage>
 
 class QXmlStreamReader;
 class QXmlStreamWriter;

--- a/src/xlsx/xlsxformat.cpp
+++ b/src/xlsx/xlsxformat.cpp
@@ -29,6 +29,7 @@
 #include <QDataStream>
 #include <QDebug>
 
+
 QT_BEGIN_NAMESPACE_XLSX
 
 FormatPrivate::FormatPrivate()

--- a/src/xlsx/xlsxglobal.h
+++ b/src/xlsx/xlsxglobal.h
@@ -26,6 +26,15 @@
 #define XLSXGLOBAL_H
 #include <QtGlobal>
 
+#if QT_VERSION < 0x050000
+#ifndef QStringLiteral
+# define QStringLiteral(str) QString::fromUtf8("" str "", sizeof(str) - 1)
+#endif
+#define Q_DECL_NOTHROW
+//#define UnknownType Void
+#endif
+
+
 #define QT_BEGIN_NAMESPACE_XLSX namespace QXlsx {
 #define QT_END_NAMESPACE_XLSX }
 #define QTXLSX_USE_NAMESPACE using namespace QXlsx;

--- a/src/xlsx/xlsxrelationships.cpp
+++ b/src/xlsx/xlsxrelationships.cpp
@@ -92,7 +92,7 @@ QList<XlsxRelationship> Relationships::relationships(const QString &type) const
 void Relationships::addRelationship(const QString &type, const QString &target, const QString &targetMode)
 {
     XlsxRelationship relation;
-    relation.id = QStringLiteral("rId%1").arg(m_relationships.size()+1);
+    relation.id = QString("rId%1").arg(m_relationships.size()+1);
     relation.type = type;
     relation.target = target;
     relation.targetMode = targetMode;

--- a/src/xlsx/xlsxrichstring.cpp
+++ b/src/xlsx/xlsxrichstring.cpp
@@ -329,7 +329,12 @@ bool operator !=(const QString &rs1, const RichString &rs2)
 
 uint qHash(const RichString &rs, uint seed) Q_DECL_NOTHROW
 {
-    return qHash(rs.d->idKey(), seed);
+#if QT_VERSION >= 0x050000
+  return qHash(rs.d->idKey(), seed);
+#else
+  return ::qHash(rs.d->idKey()) ^ seed;
+#endif
+
 }
 
 #ifndef QT_NO_DEBUG_STREAM

--- a/src/xlsx/xlsxsharedstrings_p.h
+++ b/src/xlsx/xlsxsharedstrings_p.h
@@ -67,7 +67,7 @@ public:
     SharedStrings(CreateFlag flag);
     int count() const;
     bool isEmpty() const;
-    
+
     int addSharedString(const QString &string);
     int addSharedString(const RichString &string);
     void removeSharedString(const QString &string);

--- a/src/xlsx/xlsxstyles.cpp
+++ b/src/xlsx/xlsxstyles.cpp
@@ -34,6 +34,12 @@
 #include <QDebug>
 #include <QBuffer>
 
+#if QT_VERSION < 0x050000
+#define QMetaType_UnknownType QMetaType::Void
+#else
+#define QMetaType_UnknownType QMetaType::UnknownType
+#endif
+
 namespace QXlsx {
 
 /*
@@ -48,7 +54,7 @@ Styles::Styles(CreateFlag flag)
     //!Fix me. Should the custom num fmt Id starts with 164 or 176 or others??
 
     //!Fix me! Where should we put these register code?
-    if (QMetaType::type("XlsxColor") == QMetaType::UnknownType) {
+    if (QMetaType::type("XlsxColor") == QMetaType_UnknownType) {
         qRegisterMetaType<XlsxColor>("XlsxColor");
         qRegisterMetaTypeStreamOperators<XlsxColor>("XlsxColor");
 #if QT_VERSION >= 0x050200

--- a/src/xlsx/xlsxutility.cpp
+++ b/src/xlsx/xlsxutility.cpp
@@ -27,12 +27,18 @@
 
 #include <QString>
 #include <QPoint>
-#include <QRegularExpression>
 #include <QMap>
 #include <QStringList>
 #include <QColor>
 #include <QDateTime>
 #include <QDebug>
+
+#if QT_VERSION < 0x050000
+  #include <QRegExp>
+  #define QRegularExpression QRegExp
+#else
+  #include <QRegularExpression>
+#endif
 
 namespace QXlsx {
 

--- a/src/xlsx/xlsxworksheet.cpp
+++ b/src/xlsx/xlsxworksheet.cpp
@@ -42,12 +42,12 @@
 #include "xlsxcellformula.h"
 #include "xlsxcellformula_p.h"
 
+
 #include <QVariant>
 #include <QDateTime>
 #include <QPoint>
 #include <QFile>
 #include <QUrl>
-#include <QRegularExpression>
 #include <QDebug>
 #include <QBuffer>
 #include <QXmlStreamWriter>
@@ -2299,6 +2299,7 @@ bool Worksheet::loadFromXmlFile(QIODevice *device)
     }
 
     d->validateDimension();
+    //qDebug() << sheetName() << dimension().firstRow() << dimension().lastRow();
     return true;
 }
 

--- a/src/xlsx/xlsxworksheet_p.h
+++ b/src/xlsx/xlsxworksheet_p.h
@@ -45,7 +45,13 @@
 
 #include <QImage>
 #include <QSharedPointer>
-#include <QRegularExpression>
+
+#if QT_VERSION < 0x050000
+  #include <QRegExp>
+  #define QRegularExpression QRegExp
+#else
+  #include <QRegularExpression>
+#endif
 
 class QXmlStreamWriter;
 class QXmlStreamReader;
@@ -142,7 +148,7 @@ struct XlsxColumnInfo
     int firstColumn;
     int lastColumn;
     bool customWidth;
-    double width;    
+    double width;
     Format format;
     bool hidden;
     int outlineLevel;

--- a/src/xlsx/xlsxzipreader.cpp
+++ b/src/xlsx/xlsxzipreader.cpp
@@ -22,34 +22,33 @@
 ** WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 **
 ****************************************************************************/
-
 #include "xlsxzipreader_p.h"
+#include "qzlibreader.h"
 
-#include <private/qzipreader_p.h>
 
 namespace QXlsx {
 
-ZipReader::ZipReader(const QString &filePath) :
-    m_reader(new QZipReader(filePath))
+ZipReader::ZipReader(const QString &filePath)
 {
+    m_reader = new QZLibReader(filePath);
     init();
 }
 
-ZipReader::ZipReader(QIODevice *device) :
-    m_reader(new QZipReader(device))
+ZipReader::ZipReader(QIODevice *device)
 {
-    init();
+  m_reader = new QZLibReader(device);
+  init();
 }
 
 ZipReader::~ZipReader()
 {
-
+  delete m_reader;
 }
 
 void ZipReader::init()
 {
-    QList<QZipReader::FileInfo> allFiles = m_reader->fileInfoList();
-    foreach (const QZipReader::FileInfo &fi, allFiles) {
+    QList<QZLibReader::FileInfo> allFiles = m_reader->fileInfoList();
+    foreach (const QZLibReader::FileInfo &fi, allFiles) {
         if (fi.isFile)
             m_filePaths.append(fi.filePath);
     }

--- a/src/xlsx/xlsxzipreader_p.h
+++ b/src/xlsx/xlsxzipreader_p.h
@@ -40,7 +40,7 @@
 #include "xlsxglobal.h"
 #include <QScopedPointer>
 #include <QStringList>
-class QZipReader;
+class QZLibReader;
 class QIODevice;
 
 namespace QXlsx {
@@ -58,7 +58,7 @@ public:
 private:
     Q_DISABLE_COPY(ZipReader)
     void init();
-    QScopedPointer<QZipReader> m_reader;
+    QZLibReader *m_reader;
     QStringList m_filePaths;
 };
 

--- a/src/xlsx/xlsxzipwriter.cpp
+++ b/src/xlsx/xlsxzipwriter.cpp
@@ -24,20 +24,20 @@
 ****************************************************************************/
 #include "xlsxzipwriter_p.h"
 #include <QDebug>
-#include <private/qzipwriter_p.h>
+#include "qzlibwriter.h"
 
 namespace QXlsx {
 
 ZipWriter::ZipWriter(const QString &filePath)
 {
-    m_writer = new QZipWriter(filePath, QIODevice::WriteOnly);
-    m_writer->setCompressionPolicy(QZipWriter::AutoCompress);
+    m_writer = new QZLibWriter(filePath, QIODevice::WriteOnly);
+    m_writer->setCompressionPolicy(QZLibWriter::AutoCompress);
 }
 
 ZipWriter::ZipWriter(QIODevice *device)
 {
-    m_writer = new QZipWriter(device);
-    m_writer->setCompressionPolicy(QZipWriter::AutoCompress);
+    m_writer = new QZLibWriter(device);
+    m_writer->setCompressionPolicy(QZLibWriter::AutoCompress);
 }
 
 ZipWriter::~ZipWriter()
@@ -47,7 +47,7 @@ ZipWriter::~ZipWriter()
 
 bool ZipWriter::error() const
 {
-    return m_writer->status() != QZipWriter::NoError;
+    return m_writer->status() != QZLibWriter::NoError;
 }
 
 void ZipWriter::addFile(const QString &filePath, QIODevice *device)

--- a/src/xlsx/xlsxzipwriter_p.h
+++ b/src/xlsx/xlsxzipwriter_p.h
@@ -38,7 +38,7 @@
 
 #include <QString>
 class QIODevice;
-class QZipWriter;
+class QZLibWriter;
 
 namespace QXlsx {
 
@@ -55,7 +55,7 @@ public:
     void close();
 
 private:
-    QZipWriter *m_writer;
+    QZLibWriter *m_writer;
 };
 
 } // namespace QXlsx


### PR DESCRIPTION
For my old Qt4 project I make QtXlsxWriter simple and dirty Qt4 backport:
- Insert QStringLiteral macro
- Replace qt private classes QZipReader & QZipWriter to their copies QZlibReader & QZlibWriter
- Few not significant changes 
