### PR TITLE
exposing definedNames functionality; additional api for automation

### DIFF
--- a/src/xlsx/xlsxcellrange.cpp
+++ b/src/xlsx/xlsxcellrange.cpp
@@ -85,7 +85,8 @@ CellRange::CellRange(const char *range)
 
 void CellRange::init(const QString &range)
 {
-    QStringList rs = range.split(QLatin1Char(':'));
+    QStringList rs = range.split(QLatin1Char('!'));
+    rs = rs[rs.size()-1].split(QLatin1Char(':'));
     if (rs.size() == 2) {
         CellReference start(rs[0]);
         CellReference end(rs[1]);

--- a/src/xlsx/xlsxdocument.cpp
+++ b/src/xlsx/xlsxdocument.cpp
@@ -369,6 +369,7 @@ Document::Document(QObject *parent) :
     QObject(parent), d_ptr(new DocumentPrivate(this))
 {
     d_ptr->init();
+    loaded = 0;
 }
 
 /*!
@@ -379,11 +380,12 @@ Document::Document(QObject *parent) :
 Document::Document(const QString &name, QObject *parent) :
     QObject(parent), d_ptr(new DocumentPrivate(this))
 {
+    loaded = 0;
     d_ptr->packageName = name;
     if (QFile::exists(name)) {
         QFile xlsx(name);
         if (xlsx.open(QFile::ReadOnly))
-            d_ptr->loadPackage(&xlsx);
+            loaded = d_ptr->loadPackage(&xlsx);
     }
     d_ptr->init();
 }
@@ -396,8 +398,9 @@ Document::Document(const QString &name, QObject *parent) :
 Document::Document(QIODevice *device, QObject *parent) :
     QObject(parent), d_ptr(new DocumentPrivate(this))
 {
+    loaded = 0;
     if (device && device->isReadable())
-        d_ptr->loadPackage(device);
+        loaded = d_ptr->loadPackage(device);
     d_ptr->init();
 }
 
@@ -1033,6 +1036,14 @@ bool Document::saveAs(QIODevice *device) const
 {
     Q_D(const Document);
     return d->savePackage(device);
+}
+
+/*!
+* Returns true if document was loaded successfully.
+*/
+bool Document::isLoaded() const
+{
+    return loaded;
 }
 
 /*!

--- a/src/xlsx/xlsxdocument.h
+++ b/src/xlsx/xlsxdocument.h
@@ -123,9 +123,12 @@ public:
     bool saveAs(const QString &xlsXname) const;
     bool saveAs(QIODevice *device) const;
 
+    bool isLoaded() const;
+
 private:
     Q_DISABLE_COPY(Document)
     DocumentPrivate * const d_ptr;
+    bool loaded;
 };
 
 QT_END_NAMESPACE_XLSX

--- a/src/xlsx/xlsxworkbook.cpp
+++ b/src/xlsx/xlsxworkbook.cpp
@@ -186,6 +186,100 @@ bool Workbook::defineName(const QString &name, const QString &formula, const QSt
     return true;
 }
 
+bool Workbook::definedName(const QString &name, QString &formula, QString &comment, const QString &scope)
+{
+    Q_D(Workbook);
+
+    int id = -1;
+    if (!scope.isEmpty()) {
+        for (int i = 0; i < d->sheets.size(); ++i) {
+            if (d->sheets[i]->sheetName() == scope) {
+                id = d->sheets[i]->sheetId();
+                break;
+            }
+        }
+    }
+
+    for (int i = 0; i < d->definedNamesList.size(); ++i) {
+        if (d->definedNamesList[i].sheetId == id && d->definedNamesList[i].name == name) {
+            formula = d->definedNamesList[i].formula;
+            comment = d->definedNamesList[i].comment;
+            return true;
+        }
+    }
+    return false;
+}
+
+bool Workbook::definedName(int index, QString &name, QString &formula, QString &comment, const QString &scope)
+{
+    Q_D(Workbook);
+
+    int id = -1;
+    if (!scope.isEmpty()) {
+        for (int i = 0; i < d->sheets.size(); ++i) {
+            if (d->sheets[i]->sheetName() == scope) {
+                id = d->sheets[i]->sheetId();
+                break;
+            }
+        }
+    }
+
+    int pos = -1;
+    for (int i = 0; i < d->definedNamesList.size(); ++i) {
+        if (d->definedNamesList[i].sheetId == id) {
+            ++pos;
+        }
+        if (d->definedNamesList[i].sheetId == id && pos == index) {
+            name = d->definedNamesList[i].name;
+            formula = d->definedNamesList[i].formula;
+            comment = d->definedNamesList[i].comment;
+            return true;
+        }
+    }
+    return false;
+}
+
+bool Workbook::definedNameGlobal(int index, QString &name, QString &formula, QString &comment, QString &scope)
+{
+    Q_D(Workbook);
+
+    if (index < d->definedNamesList.count()) {
+        name = d->definedNamesList[index].name;
+        formula = d->definedNamesList[index].formula;
+        comment = d->definedNamesList[index].comment;
+        for (int i = 0; i < d->sheets.size(); ++i) {
+            if (d->sheets[i]->sheetId() == d->definedNamesList[index].sheetId) {
+                scope = d->sheets[i]->sheetName();
+                break;
+            }
+        }
+        return true;
+    }
+    return false;
+}
+
+int Workbook::definedNameCount(const QString &scope)
+{
+    Q_D(Workbook);
+
+    int count = 0;
+    int id = -1;
+    if (!scope.isEmpty()) {
+        for (int i = 0; i < d->sheets.size(); ++i) {
+            if (d->sheets[i]->sheetName() == scope) {
+                id = d->sheets[i]->sheetId();
+                break;
+            }
+        }
+    }
+    for (int i = 0; i < d->definedNamesList.size(); ++i) {
+        if (d->definedNamesList[i].sheetId == id) {
+            ++count;
+        }
+    }
+    return count;
+}
+
 AbstractSheet *Workbook::addSheet(const QString &name, AbstractSheet::SheetType type)
 {
     Q_D(Workbook);

--- a/src/xlsx/xlsxworkbook.h
+++ b/src/xlsx/xlsxworkbook.h
@@ -70,6 +70,10 @@ public:
 
 //    void addChart();
     bool defineName(const QString &name, const QString &formula, const QString &comment=QString(), const QString &scope=QString());
+    bool definedName(const QString &name, QString &formula, QString &comment, const QString &scope = QString());
+    bool definedName(int index, QString &name, QString &formula, QString &comment, const QString &scope = QString());
+    bool definedNameGlobal(int index, QString &name, QString &formula, QString &comment, QString &scope);
+    int  definedNameCount(const QString &scope = QString());
     bool isDate1904() const;
     void setDate1904(bool date1904);
     bool isStringsToNumbersEnabled() const;


### PR DESCRIPTION
Adding additional Defined Names API + Document::isLoaded() API to cover basic automation use-case.

So the Defines Names support was already there for create/save/load, I have added read/iterate API.

Two other minor changes: document:isloaded() API and CellRange constructor being able to handle range string with sheet! name included.

Should be a useful addition. Considerations?