### PR TITLE
Allow build of main library and tests using CMake rather than QMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,14 +2,14 @@ cmake_minimum_required(VERSION 3.2)
 
 project(QtXlsxWriter)
 add_definitions(-DQT_BUILD_XLSX_LIB)
-SET (BUILD_SHARED_LIBS TRUE)
-
+set(BUILD_SHARED_LIBS TRUE)
 set(CMAKE_AUTOMOC ON)
 
 file(
 	GLOB
 	QtXlsxWriter_SOURCE_FILES 
 	${CMAKE_CURRENT_SOURCE_DIR}/src/xlsx/*.cpp
+  ${CMAKE_CURRENT_BINARY_DIR}/QtXlsxWriterTest_automoc.cpp
 )
 
 find_package(Qt5 5.5 REQUIRED Core Gui Test)
@@ -26,11 +26,7 @@ target_link_libraries(QtXlsxWriter ${Qt5Core_LIBRARIES})
 target_link_libraries(QtXlsxWriter ${Qt5Gui_LIBRARIES})
 
 if(BUILD_TESTS)
-
-add_custom_command(TARGET QtXlsxWriter POST_BUILD
-  COMMAND ${CMAKE_COMMAND} 
-  -E copy_directory $<CONFIGURATION>/ ${CMAKE_CURRENT_BINARY_DIR}/tests/auto/$<CONFIGURATION>/)
-	add_subdirectory(tests)
+  add_subdirectory(tests)
 endif()
 
 if(BUILD_EXAMPLES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,14 @@ include_directories(
 
 add_library(QtXlsxWriter SHARED "${QtXlsxWriter_SOURCE_FILES}")
 
-set_target_properties(QtXlsxWriter PROPERTIES DEBUG_POSTFIX "d")
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    set_target_properties(QtXlsxWriter PROPERTIES DEBUG_POSTFIX "_debug")
+endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+      
+if(WIN32)
+    set_target_properties(QtXlsxWriter PROPERTIES DEBUG_POSTFIX "d")
+endif(WIN32)
+
 target_link_libraries(QtXlsxWriter ${Qt5Core_LIBRARIES})
 target_link_libraries(QtXlsxWriter ${Qt5Gui_LIBRARIES})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,10 @@ add_definitions(-DQT_BUILD_XLSX_LIB)
 set(BUILD_SHARED_LIBS TRUE)
 set(CMAKE_AUTOMOC ON)
 
+if (NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE "Release")
+endif()
+
 file(
 	GLOB
 	QtXlsxWriter_SOURCE_FILES 
@@ -32,3 +36,36 @@ endif()
 if(BUILD_EXAMPLES)
 	add_subdirectory(examples)
 endif()
+
+#####
+#
+# Installation configuration
+#
+#####
+INSTALL(TARGETS QtXlsxWriter
+  RUNTIME DESTINATION ${CMAKE_BUILD_TYPE}/bin
+  LIBRARY DESTINATION ${CMAKE_BUILD_TYPE}/lib
+  ARCHIVE DESTINATION ${CMAKE_BUILD_TYPE}/lib
+)
+
+SET(INCLUDE_FILES 
+  src/xlsx/xlsxabstractooxmlfile.h
+  src/xlsx/xlsxabstractsheet.h
+  src/xlsx/xlsxcell.h
+  src/xlsx/xlsxcellformula.h
+  src/xlsx/xlsxcellrange.h
+  src/xlsx/xlsxcellreference.h
+  src/xlsx/xlsxchart.h
+  src/xlsx/xlsxchartsheet.h
+  src/xlsx/xlsxconditionalformatting.h
+  src/xlsx/xlsxdatavalidation.h
+  src/xlsx/xlsxdocument.h
+  src/xlsx/xlsxformat.h
+  src/xlsx/xlsxglobal.h
+  src/xlsx/xlsxrichstring.h
+  src/xlsx/xlsxworkbook.h
+  src/xlsx/xlsxworksheet.h
+)
+INSTALL(FILES ${INCLUDE_FILES} DESTINATION ${CMAKE_BUILD_TYPE}/include)
+
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,13 @@ if(BUILD_TESTS)
 endif()
 
 if(BUILD_EXAMPLES)
-	add_subdirectory(examples)
+
+  
+    add_custom_command(TARGET QtXlsxWriter POST_BUILD
+        COMMAND ${CMAKE_COMMAND}
+        -E copy_directory $<CONFIGURATION> ${CMAKE_CURRENT_BINARY_DIR}/examples/xlsx/$<CONFIGURATION>)
+
+	add_subdirectory(examples/xlsx)
 endif()
 
 #####

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,11 @@
 cmake_minimum_required(VERSION 3.2)
 
 project(QtXlsxWriter)
-add_definitions(-DXLSX_NO_LIB)
-SET (BUILD_SHARED_LIBS  TRUE) 
+add_definitions(-DQT_BUILD_XLSX_LIB)
+SET (BUILD_SHARED_LIBS TRUE)
 
 set(CMAKE_AUTOMOC ON)
+
 file(
 	GLOB
 	QtXlsxWriter_SOURCE_FILES 
@@ -20,10 +21,15 @@ include_directories(
 
 add_library(QtXlsxWriter SHARED "${QtXlsxWriter_SOURCE_FILES}")
 
+set_target_properties(QtXlsxWriter PROPERTIES DEBUG_POSTFIX "d")
 target_link_libraries(QtXlsxWriter ${Qt5Core_LIBRARIES})
 target_link_libraries(QtXlsxWriter ${Qt5Gui_LIBRARIES})
 
 if(BUILD_TESTS)
+
+add_custom_command(TARGET QtXlsxWriter POST_BUILD
+  COMMAND ${CMAKE_COMMAND} 
+  -E copy_directory $<CONFIGURATION>/ ${CMAKE_CURRENT_BINARY_DIR}/tests/auto/$<CONFIGURATION>/)
 	add_subdirectory(tests)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,32 @@
+cmake_minimum_required(VERSION 3.2)
+
+project(QtXlsxWriter)
+add_definitions(-DXLSX_NO_LIB)
+SET (BUILD_SHARED_LIBS  TRUE) 
+
+set(CMAKE_AUTOMOC ON)
+file(
+	GLOB
+	QtXlsxWriter_SOURCE_FILES 
+	${CMAKE_CURRENT_SOURCE_DIR}/src/xlsx/*.cpp
+)
+
+find_package(Qt5 5.5 REQUIRED Core Gui Test)
+include_directories(
+	${QtXlsxWriter_SOURCE_FILES} 
+	${Qt5Core_INCLUDE_DIRS} 
+	${Qt5Gui_INCLUDE_DIRS}
+	${Qt5Gui_PRIVATE_INCLUDE_DIRS} )
+
+add_library(QtXlsxWriter SHARED "${QtXlsxWriter_SOURCE_FILES}")
+
+target_link_libraries(QtXlsxWriter ${Qt5Core_LIBRARIES})
+target_link_libraries(QtXlsxWriter ${Qt5Gui_LIBRARIES})
+
+if(BUILD_TESTS)
+	add_subdirectory(tests)
+endif()
+
+if(BUILD_EXAMPLES)
+	add_subdirectory(examples)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,19 +29,24 @@ set_target_properties(QtXlsxWriter PROPERTIES DEBUG_POSTFIX "d")
 target_link_libraries(QtXlsxWriter ${Qt5Core_LIBRARIES})
 target_link_libraries(QtXlsxWriter ${Qt5Gui_LIBRARIES})
 
-if(BUILD_TESTS)
+if(BUILD_TESTING)
   add_subdirectory(tests)
 endif()
 
 if(BUILD_EXAMPLES)
-
-  
     add_custom_command(TARGET QtXlsxWriter POST_BUILD
         COMMAND ${CMAKE_COMMAND}
         -E copy_directory $<CONFIGURATION> ${CMAKE_CURRENT_BINARY_DIR}/examples/xlsx/$<CONFIGURATION>)
-
 	add_subdirectory(examples/xlsx)
 endif()
+
+##
+#
+# QtxlsxwriterVersion.cmake creation
+#
+##
+set(QtXlsxWriter_CONFIG_PATH ${CMAKE_INSTALL_PREFIX})
+configure_file(QtXlsxWriterConfig.cmake.in QtXlsxWriterConfig.cmake @ONLY)
 
 #####
 #
@@ -49,10 +54,12 @@ endif()
 #
 #####
 INSTALL(TARGETS QtXlsxWriter
-  RUNTIME DESTINATION ${CMAKE_BUILD_TYPE}/bin
-  LIBRARY DESTINATION ${CMAKE_BUILD_TYPE}/lib
-  ARCHIVE DESTINATION ${CMAKE_BUILD_TYPE}/lib
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
 )
+
+INSTALL(FILES  ${CMAKE_CURRENT_BINARY_DIR}/QtXlsxWriterConfig.cmake DESTINATION /)
 
 SET(INCLUDE_FILES 
   src/xlsx/xlsxabstractooxmlfile.h
@@ -72,6 +79,5 @@ SET(INCLUDE_FILES
   src/xlsx/xlsxworkbook.h
   src/xlsx/xlsxworksheet.h
 )
-INSTALL(FILES ${INCLUDE_FILES} DESTINATION ${CMAKE_BUILD_TYPE}/include)
-
+INSTALL(FILES ${INCLUDE_FILES} DESTINATION include)
 

--- a/QtXlsxWriterConfig.cmake.in
+++ b/QtXlsxWriterConfig.cmake.in
@@ -1,0 +1,40 @@
+#########################################
+#
+# Cmake QtXlsxWriter configuration file
+# 
+#  Usage from an external project:
+#    In your CMakeLists.txt, add these lines:
+#
+#    FIND_PACKAGE(QtXlsxWriter REQUIRED)
+#    TARGET_LINK_LIBRARIES(MY_TARGET_NAME ${QtXlsxWriter_LIBS})
+#
+#    This file will define the following variables:
+#
+#      - QtXlsxWriter_BIN                      : The list of libraries to link against (.DLL, .SO).
+#      - QtXlsxWriter_LIBS                     : The list of libraries to link against (LIB, .A).
+#      - QtXlsxWriter_LIB_DIR                  : The directory(es) where lib files are. Calling LINK_DIRECTORIES 
+#                                              with this path is NOT needed.
+#      - QtXlsxWriter_INCLUDE_DIRS             : The QtXlsxWriter include directories (automatically added)
+#
+#########################################
+
+if(CMAKE_VERSION VERSION_GREATER 2.6.2)
+    unset(QtXlsxWriter_CONFIG_PATH CACHE)
+endif()
+
+set(QtXlsxWriter_CONFIG_PATH "@QtXlsxWriter_CONFIG_PATH@")
+set(QtXlsxWriter_FOUND TRUE CACHE BOOL "" FORCE)
+set(QtXlsxWriter_LIBS QtXlsxWriter)
+set(QtXlsxWriter_LIB_BIN      ${QtXlsxWriter_CONFIG_PATH}/bin)
+set(QtXlsxWriter_LIB_DIR      ${QtXlsxWriter_CONFIG_PATH}/lib)
+set(QtXlsxWriter_INCLUDE_DIRS ${QtXlsxWriter_CONFIG_PATH}/include)
+
+include_directories(BEFORE    ${QtXlsxWriter_INCLUDE_DIRS})
+
+link_directories( ${LINK_DIRECTORIES} ${QtXlsxWriter_LIB_DIR} )
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args( QtXlsxWriter DEFAULT_MSG
+                                     QtXlsxWriter_LIBS  QtXlsxWriter_INCLUDE_DIRS)
+
+mark_as_advanced(FORCE QtXlsxWriter_LIBS QtXlsxWriter_LIB_DIR QtXlsxWriter_INCLUDE_DIRS)

--- a/examples/xlsx/CMakeLists.txt
+++ b/examples/xlsx/CMakeLists.txt
@@ -1,0 +1,50 @@
+find_package(Qt5 5.5 REQUIRED Core Gui Test Widgets)
+
+set(EXAMPLES
+    calendar
+    chart
+    chartsheet
+    conditionalformatting
+    datavalidation
+    definename
+    demo
+    documentproperty
+    extractdata
+    formulas
+    hello
+    hyperlinks
+    image
+    mergecells
+    numberformat
+    richtext
+    rowcolumn
+    style
+    worksheetoperations
+    xlsxwidget)
+
+# Compile each defined example 
+foreach(example IN ITEMS ${EXAMPLES})
+	if(DEBUG)
+		message("Create example '${example}'")
+	endif()
+	file( GLOB TEST_SRC ${example}/*.cpp)
+	include_directories(
+		${CMAKE_CURRENT_SOURCE_DIR}/../../src/xlsx/
+		${Qt5Core_INCLUDE_DIRS} 
+		${Qt5Gui_INCLUDE_DIRS}
+		${Qt5Widgets_INCLUDE_DIRS}
+        ${QtXlsxWriter_PRIVATE_SOURCE_FILES}
+		${CMAKE_CURRENT_BINARY_DIR} # .moc files
+	)
+  
+  remove_definitions(-DQT_BUILD_XLSX_LIB)
+
+  add_executable(${example} ${TEST_SRC} )
+
+  target_link_libraries(${example} ${Qt5Widgets_LIBRARIES})
+  target_link_libraries(${example} ${Qt5Core_LIBRARIES})
+  target_link_libraries(${example} ${Qt5Gui_LIBRARIES})
+  target_link_libraries(${example} ${Qt5Test_LIBRARIES})
+  target_link_libraries(${example} QtXlsxWriter)
+
+endforeach(example)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(auto)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,8 +45,16 @@ add_definitions(-DQT_BUILD_XLSX_LIB)
 add_definitions(-DXLSX_TEST)
 add_library(QtXlsxWriterTest SHARED "${QtXlsxWriterTest_SOURCE_FILES}")
   
-set_target_properties(QtXlsxWriterTest PROPERTIES DEBUG_POSTFIX "d")
-  
+
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    set_target_properties(QtXlsxWriterTest PROPERTIES DEBUG_POSTFIX "_debug")
+endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+      
+if(WIN32)
+    set_target_properties(QtXlsxWriterTest PROPERTIES DEBUG_POSTFIX "d")
+endif(WIN32)
+
+
 target_link_libraries(QtXlsxWriterTest ${Qt5Core_LIBRARIES})
 target_link_libraries(QtXlsxWriterTest ${Qt5Gui_LIBRARIES})
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,1 +1,54 @@
+# create a test-enabled library first (export more functions than regular DLL)
+
+# Create a fake private/ include folder 
+# in the compilation tree to allow the
+# #include "private/..." instruction to
+# work
+set( 
+	QtXlsxWriter_PRIVATE_SOURCE_FILES 
+    	${CMAKE_CURRENT_BINARY_DIR}/include)
+
+if(DEBUG)
+	message("Private include directory : ${QtXlsxWriter_PRIVATE_SOURCE_FILES}")
+endif()
+file(MAKE_DIRECTORY "${QtXlsxWriter_PRIVATE_SOURCE_FILES}/private")
+
+# Copy all private includes in the created folder
+file(GLOB private_includes ${CMAKE_CURRENT_SOURCE_DIR}/../src/xlsx/*_p.h)
+foreach(private_include ${private_includes})
+	if(DEBUG)
+		message("Copying private include : ${private_include}") 
+	endif()
+	file(COPY ${private_include} DESTINATION ${QtXlsxWriter_PRIVATE_SOURCE_FILES}/private)
+endforeach()
+
+set(CMAKE_AUTOMOC ON)
+
+file(
+  GLOB
+  QtXlsxWriterTest_SOURCE_FILES
+  ${CMAKE_CURRENT_SOURCE_DIR}/../src/xlsx/*.cpp
+  ${CMAKE_CURRENT_BINARY_DIR}/QtXlsxWriter_automoc.cpp
+)
+
+include_directories(
+  ${CMAKE_CURRENT_BINARY_DIR}
+  ${Qt5Core_INCLUDE_DIRS} 
+  ${Qt5Gui_INCLUDE_DIRS}
+  ${Qt5Gui_PRIVATE_INCLUDE_DIRS}
+)
+  
+add_definitions(-DQT_BUILD_XLSX_LIB)
+add_definitions(-DXLSX_TEST)
+add_library(QtXlsxWriterTest SHARED "${QtXlsxWriterTest_SOURCE_FILES}")
+  
+set_target_properties(QtXlsxWriterTest PROPERTIES DEBUG_POSTFIX "d")
+  
+target_link_libraries(QtXlsxWriterTest ${Qt5Core_LIBRARIES})
+target_link_libraries(QtXlsxWriterTest ${Qt5Gui_LIBRARIES})
+
+add_custom_command(TARGET QtXlsxWriterTest POST_BUILD
+                     COMMAND ${CMAKE_COMMAND}
+                     -E copy_directory $<CONFIGURATION> auto/$<CONFIGURATION>)
+
 add_subdirectory(auto)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,7 @@
-# create a test-enabled library first (export more functions than regular DLL)
+#
+# create a test-enabled library before creating tests
+# themselves (export more functions than regular DLL)
+#
 
 # Create a fake private/ include folder 
 # in the compilation tree to allow the

--- a/tests/auto/CMakeLists.txt
+++ b/tests/auto/CMakeLists.txt
@@ -12,35 +12,11 @@ set(TESTS
 	worksheet 
 	xlsxconditionalformatting 
 	zipreader)
-
-
+  
 enable_testing()
 
-# Create a fake private/ include folder in
-# the compilation tree
-set( 
-	QtXlsxWriter_PRIVATE_SOURCE_FILES 
-    	${CMAKE_CURRENT_BINARY_DIR}/include)
-
-if(DEBUG)
-	message("Private include directory : ${QtXlsxWriter_PRIVATE_SOURCE_FILES}")
-endif()
-
-file(MAKE_DIRECTORY "${QtXlsxWriter_PRIVATE_SOURCE_FILES}/private")
-
-
-# and copy all private includes in it
-file(GLOB private_includes ${CMAKE_CURRENT_SOURCE_DIR}/../../src/xlsx/*_p.h)
-foreach(private_include ${private_includes})
-	if(DEBUG)
-		message("Copying private include : ${private_include}") 
-	endif()
-	file(COPY ${private_include} DESTINATION ${QtXlsxWriter_PRIVATE_SOURCE_FILES}/private)
-endforeach()
-
-add_definitions(-DXLSX_TESTS)
-add_definitions(-DXLSX_NO_LIB)
-
+# Compile each defined test and
+# declare it for ctest tool
 foreach(test IN ITEMS ${TESTS})
 	if(DEBUG)
 		message("configure test '${test}'")
@@ -50,13 +26,20 @@ foreach(test IN ITEMS ${TESTS})
 		${CMAKE_CURRENT_SOURCE_DIR}/../../src/xlsx/
 		${Qt5Core_INCLUDE_DIRS} 
 		${Qt5Gui_INCLUDE_DIRS}
-		${QtXlsxWriter_PRIVATE_SOURCE_FILES}
+    ${QtXlsxWriter_PRIVATE_SOURCE_FILES}
 		${CMAKE_CURRENT_BINARY_DIR} # .moc files
 	)
-	add_executable(${test}_testDriver ${TEST_SRC})
-  	target_link_libraries(${test}_testDriver QtXlsxWriter)
-	target_link_libraries(${test}_testDriver ${Qt5Core_LIBRARIES})
+  
+  add_definitions(-DXLSX_TEST)
+  remove_definitions(-DQT_BUILD_XLSX_LIB)
+
+	add_executable(${test}_testDriver ${TEST_SRC} )
+
+  target_link_libraries(${test}_testDriver ${Qt5Core_LIBRARIES})
 	target_link_libraries(${test}_testDriver ${Qt5Gui_LIBRARIES})
 	target_link_libraries(${test}_testDriver ${Qt5Test_LIBRARIES})
-	add_test(NAME ${test} COMMAND ${test}_testDriver)
+  target_link_libraries(${test}_testDriver QtXlsxWriterTest)
+
+  add_test(NAME ${test} COMMAND ${test}_testDriver)
+
 endforeach(test)

--- a/tests/auto/CMakeLists.txt
+++ b/tests/auto/CMakeLists.txt
@@ -28,6 +28,7 @@ endif()
 
 file(MAKE_DIRECTORY "${QtXlsxWriter_PRIVATE_SOURCE_FILES}/private")
 
+
 # and copy all private includes in it
 file(GLOB private_includes ${CMAKE_CURRENT_SOURCE_DIR}/../../src/xlsx/*_p.h)
 foreach(private_include ${private_includes})
@@ -37,8 +38,9 @@ foreach(private_include ${private_includes})
 	file(COPY ${private_include} DESTINATION ${QtXlsxWriter_PRIVATE_SOURCE_FILES}/private)
 endforeach()
 
-
 add_definitions(-DXLSX_TESTS)
+add_definitions(-DXLSX_NO_LIB)
+
 foreach(test IN ITEMS ${TESTS})
 	if(DEBUG)
 		message("configure test '${test}'")
@@ -56,5 +58,5 @@ foreach(test IN ITEMS ${TESTS})
 	target_link_libraries(${test}_testDriver ${Qt5Core_LIBRARIES})
 	target_link_libraries(${test}_testDriver ${Qt5Gui_LIBRARIES})
 	target_link_libraries(${test}_testDriver ${Qt5Test_LIBRARIES})
-	add_test(NAME ${test} COMMAND ${test}_testDriver -C $<CONFIGURATION>)
+	add_test(NAME ${test} COMMAND ${test}_testDriver)
 endforeach(test)

--- a/tests/auto/CMakeLists.txt
+++ b/tests/auto/CMakeLists.txt
@@ -1,0 +1,60 @@
+set(TESTS 
+	cellreference  
+	document 
+	format 
+	propsapp 
+	propscore 
+	relationships 
+	richstring 
+	sharedstrings 
+	styles 
+	utility 
+	worksheet 
+	xlsxconditionalformatting 
+	zipreader)
+
+
+enable_testing()
+
+# Create a fake private/ include folder in
+# the compilation tree
+set( 
+	QtXlsxWriter_PRIVATE_SOURCE_FILES 
+    	${CMAKE_CURRENT_BINARY_DIR}/include)
+
+if(DEBUG)
+	message("Private include directory : ${QtXlsxWriter_PRIVATE_SOURCE_FILES}")
+endif()
+
+file(MAKE_DIRECTORY "${QtXlsxWriter_PRIVATE_SOURCE_FILES}/private")
+
+# and copy all private includes in it
+file(GLOB private_includes ${CMAKE_CURRENT_SOURCE_DIR}/../../src/xlsx/*_p.h)
+foreach(private_include ${private_includes})
+	if(DEBUG)
+		message("Copying private include : ${private_include}") 
+	endif()
+	file(COPY ${private_include} DESTINATION ${QtXlsxWriter_PRIVATE_SOURCE_FILES}/private)
+endforeach()
+
+
+add_definitions(-DXLSX_TESTS)
+foreach(test IN ITEMS ${TESTS})
+	if(DEBUG)
+		message("configure test '${test}'")
+	endif()
+	file( GLOB TEST_SRC ${test}/*.cpp)
+	include_directories(
+		${CMAKE_CURRENT_SOURCE_DIR}/../../src/xlsx/
+		${Qt5Core_INCLUDE_DIRS} 
+		${Qt5Gui_INCLUDE_DIRS}
+		${QtXlsxWriter_PRIVATE_SOURCE_FILES}
+		${CMAKE_CURRENT_BINARY_DIR} # .moc files
+	)
+	add_executable(${test}_testDriver ${TEST_SRC})
+  	target_link_libraries(${test}_testDriver QtXlsxWriter)
+	target_link_libraries(${test}_testDriver ${Qt5Core_LIBRARIES})
+	target_link_libraries(${test}_testDriver ${Qt5Gui_LIBRARIES})
+	target_link_libraries(${test}_testDriver ${Qt5Test_LIBRARIES})
+	add_test(NAME ${test} COMMAND ${test}_testDriver -C $<CONFIGURATION>)
+endforeach(test)


### PR DESCRIPTION
For instance, the patch allow : 
- Configuration and compilation of main library
- Compilation of tests and examples
- Creation of the CMake configuration file
