### PR TITLE
Properly check existence of protection data

### DIFF
--- a/src/xlsx/xlsxformat.cpp
+++ b/src/xlsx/xlsxformat.cpp
@@ -1126,8 +1126,8 @@ bool Format::hasProtectionData() const
     if (!d)
         return false;
 
-    if (hasProperty(FormatPrivate::P_Protection_Hidden
-            || FormatPrivate::P_Protection_Locked)) {
+    if (hasProperty(FormatPrivate::P_Protection_Hidden)
+            || hasProperty(FormatPrivate::P_Protection_Locked)) {
         return true;
     }
     return false;


### PR DESCRIPTION
Each of the flags needs to be checked separately. Combining the flags
via boolean or doesn't give the expected result and makes the compiler
warn about "enum constant in boolean context [-Wint-in-bool-context]".