### PR TITLE
[WIP] Write sheet and cell protection info

### DIFF
--- a/src/xlsx/xlsxstyles.cpp
+++ b/src/xlsx/xlsxstyles.cpp
@@ -648,6 +648,13 @@ void Styles::writeCellXfs(QXmlStreamWriter &writer) const
                 writer.writeAttribute(QStringLiteral("textRotation"), QString::number(format.rotation()));
         }
 
+        if (format.hasProtectionData()) {
+            writer.writeStartElement(QStringLiteral("protection"));
+            writer.writeAttribute(QStringLiteral("locked"), format.locked() ? QStringLiteral("1") : QStringLiteral("0"));
+            writer.writeAttribute(QStringLiteral("hidden"), format.hidden() ? QStringLiteral("1") : QStringLiteral("0"));
+            writer.writeEndElement();//protection
+        }
+
         writer.writeEndElement();//xf
     }
     writer.writeEndElement();//cellXfs

--- a/src/xlsx/xlsxstyles.cpp
+++ b/src/xlsx/xlsxstyles.cpp
@@ -589,6 +589,8 @@ void Styles::writeCellXfs(QXmlStreamWriter &writer) const
             writer.writeAttribute(QStringLiteral("applyBorder"), QStringLiteral("1"));
         if (format.hasAlignmentData())
             writer.writeAttribute(QStringLiteral("applyAlignment"), QStringLiteral("1"));
+        if (format.hasProtectionData())
+            writer.writeAttribute(QStringLiteral("applyProtection"), QStringLiteral("1"));
 
         if (format.hasAlignmentData()) {
             writer.writeEmptyElement(QStringLiteral("alignment"));

--- a/src/xlsx/xlsxworksheet.cpp
+++ b/src/xlsx/xlsxworksheet.cpp
@@ -235,7 +235,7 @@ Worksheet::~Worksheet()
 }
 
 /*!
- * Returns whether sheet is protected.
+ * Returns whether the sheet window is protected.
  */
 bool Worksheet::isWindowProtected() const
 {
@@ -244,12 +244,30 @@ bool Worksheet::isWindowProtected() const
 }
 
 /*!
- * Protects/unprotects the sheet based on \a protect.
+ * Protects/unprotects the sheet window based on \a protect.
  */
 void Worksheet::setWindowProtected(bool protect)
 {
     Q_D(Worksheet);
     d->windowProtection = protect;
+}
+
+/*!
+ * Returns whether the sheet data is protected.
+ */
+bool Worksheet::isSheetProtected() const
+{
+    Q_D(const Worksheet);
+    return d->sheetProtection;
+}
+
+/*!
+ * Protects/unprotects the sheet data based on \a protect.
+ */
+void Worksheet::setSheetProtected(bool protect)
+{
+    Q_D(Worksheet);
+    d->sheetProtection = protect;
 }
 
 /*!
@@ -1229,6 +1247,13 @@ void Worksheet::saveToXmlFile(QIODevice *device) const
     if (d->dimension.isValid())
         d->saveXmlSheetData(writer);
     writer.writeEndElement();//sheetData
+
+    if (d->sheetProtection) {
+        writer.writeStartElement(QStringLiteral("sheetProtection"));
+        writer.writeAttribute(QStringLiteral("sheet"), QStringLiteral("1"));
+        writer.writeAttribute(QStringLiteral("selectLockedCells"), QStringLiteral("1"));
+        writer.writeEndElement();//sheetProtection
+    }
 
     d->saveXmlMergeCells(writer);
     foreach (const ConditionalFormatting cf, d->conditionalFormattingList)

--- a/src/xlsx/xlsxworksheet.cpp
+++ b/src/xlsx/xlsxworksheet.cpp
@@ -61,9 +61,36 @@ QT_BEGIN_NAMESPACE_XLSX
 
 WorksheetPrivate::WorksheetPrivate(Worksheet *p, Worksheet::CreateFlag flag)
     : AbstractSheetPrivate(p, flag)
-  , windowProtection(false), showFormulas(false), showGridLines(true), showRowColHeaders(true)
-  , showZeros(true), rightToLeft(false), tabSelected(false), showRuler(false)
-  , showOutlineSymbols(true), showWhiteSpace(true), urlPattern(QStringLiteral("^([fh]tt?ps?://)|(mailto:)|(file://)"))
+    // window protection related props
+    , windowProtection(false)
+    , showFormulas(false)
+    , showGridLines(true)
+    , showRowColHeaders(true)
+    , showZeros(true)
+    , rightToLeft(false)
+    , tabSelected(false)
+    , showRuler(false)
+    , showOutlineSymbols(true)
+    , showWhiteSpace(true)
+    // sheet protection related props
+    , sheetProtection(false)
+    , objectsProtection(false)
+    , scenariosProtection(false)
+    , formatCellsProtection(true)
+    , formatColumnsProtection(true)
+    , formatRowsProtection(true)
+    , insertColumnsProtection(true)
+    , insertRowsProtection(true)
+    , insertHyperlinksProtection(true)
+    , deleteColumnsProtection(true)
+    , deleteRowsProtection(true)
+    , selectLockedCellsProtection(false)
+    , selectUnlockedCellsProtection(false)
+    , sortProtection(true)
+    , autoFilterProtection(true)
+    , pivotTablesProtection(true)
+    // other props
+    , urlPattern(QStringLiteral("^([fh]tt?ps?://)|(mailto:)|(file://)"))
 {
     previous_row = 0;
 
@@ -253,24 +280,6 @@ void Worksheet::setWindowProtected(bool protect)
 }
 
 /*!
- * Returns whether the sheet data is protected.
- */
-bool Worksheet::isSheetProtected() const
-{
-    Q_D(const Worksheet);
-    return d->sheetProtection;
-}
-
-/*!
- * Protects/unprotects the sheet data based on \a protect.
- */
-void Worksheet::setSheetProtected(bool protect)
-{
-    Q_D(Worksheet);
-    d->sheetProtection = protect;
-}
-
-/*!
  * Return whether formulas instead of their calculated results shown in cells
  */
 bool Worksheet::isFormulasVisible() const
@@ -433,6 +442,294 @@ void Worksheet::setWhiteSpaceVisible(bool visible)
 {
     Q_D(Worksheet);
     d->showWhiteSpace = visible;
+}
+
+/*!
+ * Returns whether the sheet data is protected.
+ */
+bool Worksheet::isSheetProtected() const
+{
+    Q_D(const Worksheet);
+    return d->sheetProtection;
+}
+
+/*!
+ * Protects/unprotects the sheet data based on \a protect.
+ */
+void Worksheet::setSheetProtected(bool protect)
+{
+    Q_D(Worksheet);
+    d->sheetProtection = protect;
+}
+
+/*!
+ * Returns whether the objects are protected when the sheet is protected
+ */
+bool Worksheet::isObjectsProtected() const
+{
+    Q_D(const Worksheet);
+    return d->objectsProtection;
+}
+
+/*!
+ * Protects/unprotects the objects based on \a protect.
+ */
+void Worksheet::setObjectsProtected(bool protect)
+{
+    Q_D(Worksheet);
+    d->objectsProtection = protect;
+}
+
+/*!
+ * Returns whether the scenarios are protected when the sheet is protected
+ */
+bool Worksheet::isScenariosProtected() const
+{
+    Q_D(const Worksheet);
+    return d->scenariosProtection;
+}
+
+/*!
+ * Protects/unprotects the scenarios based on \a protect.
+ */
+void Worksheet::setScenariosProtected(bool protect)
+{
+    Q_D(Worksheet);
+    d->scenariosProtection = protect;
+}
+
+/*!
+ * Returns whether the cell format is protected when the sheet is protected
+ */
+bool Worksheet::isFormatCellsProtected() const
+{
+    Q_D(const Worksheet);
+    return d->formatCellsProtection;
+}
+
+/*!
+ * Protects/unprotects cell formatting based on \a protect.
+ */
+void Worksheet::setFormatCellsProtected(bool protect)
+{
+    Q_D(Worksheet);
+    d->formatCellsProtection = protect;
+}
+
+/*!
+ * Returns whether the column format is protected when the sheet is protected
+ */
+bool Worksheet::isFormatColumnsProtected() const
+{
+    Q_D(const Worksheet);
+    return d->formatColumnsProtection;
+}
+
+/*!
+ * Protects/unprotects column formatting based on \a protect.
+ */
+void Worksheet::setFormatColumnsProtected(bool protect)
+{
+    Q_D(Worksheet);
+    d->formatColumnsProtection = protect;
+}
+
+/*!
+ * Returns whether the row format is protected when the sheet is protected
+ */
+bool Worksheet::isFormatRowsProtected() const
+{
+    Q_D(const Worksheet);
+    return d->formatRowsProtection;
+}
+
+/*!
+ * Protects/unprotects rows formatting based on \a protect.
+ */
+void Worksheet::setFormatRowsProtected(bool protect)
+{
+    Q_D(Worksheet);
+    d->formatRowsProtection = protect;
+}
+
+/*!
+ * Returns whether columns can be inserted when the sheet is protected
+ */
+bool Worksheet::isInsertColumnsProtected() const
+{
+    Q_D(const Worksheet);
+    return d->insertColumnsProtection;
+}
+
+/*!
+ * Protects/unprotects column insertion based on \a protect.
+ */
+void Worksheet::setInsertColumnsProtected(bool protect)
+{
+    Q_D(Worksheet);
+    d->insertColumnsProtection = protect;
+}
+
+/*!
+ * Returns whether rows can be inserted when the sheet is protected
+ */
+bool Worksheet::isInsertRowsProtected() const
+{
+    Q_D(const Worksheet);
+    return d->insertRowsProtection;
+}
+
+/*!
+ * Protects/unprotects rows insertion based on \a protect.
+ */
+void Worksheet::setInsertRowsProtected(bool protect)
+{
+    Q_D(Worksheet);
+    d->insertRowsProtection = protect;
+}
+
+/*!
+ * Returns whether hyperlinks can be inserted when the sheet is protected
+ */
+bool Worksheet::isInsertHyperlinksProtected() const
+{
+    Q_D(const Worksheet);
+    return d->insertHyperlinksProtection;
+}
+
+/*!
+ * Protects/unprotects hyperlink insertion based on \a protect.
+ */
+void Worksheet::setInsertHyperlinksProtected(bool protect)
+{
+    Q_D(Worksheet);
+    d->insertHyperlinksProtection = protect;
+}
+
+/*!
+ * Returns whether columns can be deleted when the sheet is protected
+ */
+bool Worksheet::isDeleteColumnsProtected() const
+{
+    Q_D(const Worksheet);
+    return d->deleteColumnsProtection;
+}
+
+/*!
+ * Protects/unprotects column deletion based on \a protect.
+ */
+void Worksheet::setDeleteColumnsProtected(bool protect)
+{
+    Q_D(Worksheet);
+    d->deleteColumnsProtection = protect;
+}
+
+/*!
+ * Returns whether rows can be deleted when the sheet is protected
+ */
+bool Worksheet::isDeleteRowsProtected() const
+{
+    Q_D(const Worksheet);
+    return d->deleteRowsProtection;
+}
+
+/*!
+ * Protects/unprotects row deletion based on \a protect.
+ */
+void Worksheet::setDeleteRowsProtected(bool protect)
+{
+    Q_D(Worksheet);
+    d->deleteRowsProtection = protect;
+}
+
+/*!
+ * Returns whether locked cells can be selected when the sheet is protected
+ */
+bool Worksheet::isSelectLockedCellsProtected() const
+{
+    Q_D(const Worksheet);
+    return d->selectLockedCellsProtection;
+}
+
+/*!
+ * Protects/unprotects the selection of locked cells based on \a protect.
+ */
+void Worksheet::setSelectLockedCellsProtected(bool protect)
+{
+    Q_D(Worksheet);
+    d->selectLockedCellsProtection = protect;
+}
+
+/*!
+ * Returns whether unlocked cells can be selected when the sheet is protected
+ */
+bool Worksheet::isSelectUnlockedCellsProtected() const
+{
+    Q_D(const Worksheet);
+    return d->selectUnlockedCellsProtection;
+}
+
+/*!
+ * Protects/unprotects the selection of unlocked based on \a protect.
+ */
+void Worksheet::setSelectUnlockedCellsProtected(bool protect)
+{
+    Q_D(Worksheet);
+    d->selectUnlockedCellsProtection = protect;
+}
+
+/*!
+ * Returns whether sorting is allowed when the sheet is protected
+ */
+bool Worksheet::isSortProtected() const
+{
+    Q_D(const Worksheet);
+    return d->sortProtection;
+}
+
+/*!
+ * Protects/unprotects sorting based on \a protect.
+ */
+void Worksheet::setSortProtected(bool protect)
+{
+    Q_D(Worksheet);
+    d->sortProtection = protect;
+}
+
+/*!
+ * Returns whether auto filters can operate when the sheet is protected
+ */
+bool Worksheet::isAutoFilterProtected() const
+{
+    Q_D(const Worksheet);
+    return d->autoFilterProtection;
+}
+
+/*!
+ * Protects/unprotects auto filtering based on \a protect.
+ */
+void Worksheet::setAutoFilterProtected(bool protect)
+{
+    Q_D(Worksheet);
+    d->autoFilterProtection = protect;
+}
+
+/*!
+ * Returns whether pivot tables can operate when the sheet is protected
+ */
+bool Worksheet::isPivotTablesProtected() const
+{
+    Q_D(const Worksheet);
+    return d->pivotTablesProtection;
+}
+
+/*!
+ * Protects/unprotects table pivot based on \a protect.
+ */
+void Worksheet::setPivotTablesProtected(bool protect)
+{
+    Q_D(Worksheet);
+    d->pivotTablesProtection = protect;
 }
 
 /*!

--- a/src/xlsx/xlsxworksheet.cpp
+++ b/src/xlsx/xlsxworksheet.cpp
@@ -1547,8 +1547,24 @@ void Worksheet::saveToXmlFile(QIODevice *device) const
 
     if (d->sheetProtection) {
         writer.writeStartElement(QStringLiteral("sheetProtection"));
+
         writer.writeAttribute(QStringLiteral("sheet"), QStringLiteral("1"));
-        writer.writeAttribute(QStringLiteral("selectLockedCells"), QStringLiteral("1"));
+        writer.writeAttribute(QStringLiteral("objects"), d->objectsProtection ? QStringLiteral("1") : QStringLiteral("0"));
+        writer.writeAttribute(QStringLiteral("scenarios"), d->scenariosProtection ? QStringLiteral("1") : QStringLiteral("0"));
+        writer.writeAttribute(QStringLiteral("formatCells"), d->formatCellsProtection ? QStringLiteral("1") : QStringLiteral("0"));
+        writer.writeAttribute(QStringLiteral("formatColumns"), d->formatColumnsProtection ? QStringLiteral("1") : QStringLiteral("0"));
+        writer.writeAttribute(QStringLiteral("formatRows"), d->formatRowsProtection ? QStringLiteral("1") : QStringLiteral("0"));
+        writer.writeAttribute(QStringLiteral("insertColumns"), d->insertColumnsProtection ? QStringLiteral("1") : QStringLiteral("0"));
+        writer.writeAttribute(QStringLiteral("insertRows"), d->insertRowsProtection ? QStringLiteral("1") : QStringLiteral("0"));
+        writer.writeAttribute(QStringLiteral("insertHyperlinks"), d->insertHyperlinksProtection ? QStringLiteral("1") : QStringLiteral("0"));
+        writer.writeAttribute(QStringLiteral("deleteColumns"), d->deleteColumnsProtection ? QStringLiteral("1") : QStringLiteral("0"));
+        writer.writeAttribute(QStringLiteral("deleteRows"), d->deleteRowsProtection ? QStringLiteral("1") : QStringLiteral("0"));
+        writer.writeAttribute(QStringLiteral("selectLockedCells"), d->selectLockedCellsProtection ? QStringLiteral("1") : QStringLiteral("0"));
+        writer.writeAttribute(QStringLiteral("selectUnlockedCells"), d->selectUnlockedCellsProtection ? QStringLiteral("1") : QStringLiteral("0"));
+        writer.writeAttribute(QStringLiteral("sort"), d->sortProtection ? QStringLiteral("1") : QStringLiteral("0"));
+        writer.writeAttribute(QStringLiteral("autoFilter"), d->autoFilterProtection ? QStringLiteral("1") : QStringLiteral("0"));
+        writer.writeAttribute(QStringLiteral("pivotTables"), d->pivotTablesProtection ? QStringLiteral("1") : QStringLiteral("0"));
+
         writer.writeEndElement();//sheetProtection
     }
 

--- a/src/xlsx/xlsxworksheet.h
+++ b/src/xlsx/xlsxworksheet.h
@@ -121,6 +121,8 @@ public:
 
     bool isWindowProtected() const;
     void setWindowProtected(bool protect);
+    bool isSheetProtected() const;
+    void setSheetProtected(bool protect);
     bool isFormulasVisible() const;
     void setFormulasVisible(bool visible);
     bool isGridLinesVisible() const;

--- a/src/xlsx/xlsxworksheet.h
+++ b/src/xlsx/xlsxworksheet.h
@@ -121,8 +121,6 @@ public:
 
     bool isWindowProtected() const;
     void setWindowProtected(bool protect);
-    bool isSheetProtected() const;
-    void setSheetProtected(bool protect);
     bool isFormulasVisible() const;
     void setFormulasVisible(bool visible);
     bool isGridLinesVisible() const;
@@ -141,6 +139,39 @@ public:
     void setOutlineSymbolsVisible(bool visible);
     bool isWhiteSpaceVisible() const;
     void setWhiteSpaceVisible(bool visible);
+
+    bool isSheetProtected() const;
+    void setSheetProtected(bool protect);
+    bool isObjectsProtected() const;
+    void setObjectsProtected(bool protect);
+    bool isScenariosProtected() const;
+    void setScenariosProtected(bool protect);
+    bool isFormatCellsProtected() const;
+    void setFormatCellsProtected(bool protect);
+    bool isFormatColumnsProtected() const;
+    void setFormatColumnsProtected(bool protect);
+    bool isFormatRowsProtected() const;
+    void setFormatRowsProtected(bool protect);
+    bool isInsertColumnsProtected() const;
+    void setInsertColumnsProtected(bool protect);
+    bool isInsertRowsProtected() const;
+    void setInsertRowsProtected(bool protect);
+    bool isInsertHyperlinksProtected() const;
+    void setInsertHyperlinksProtected(bool protect);
+    bool isDeleteColumnsProtected() const;
+    void setDeleteColumnsProtected(bool protect);
+    bool isDeleteRowsProtected() const;
+    void setDeleteRowsProtected(bool protect);
+    bool isSelectLockedCellsProtected() const;
+    void setSelectLockedCellsProtected(bool protect);
+    bool isSelectUnlockedCellsProtected() const;
+    void setSelectUnlockedCellsProtected(bool protect);
+    bool isSortProtected() const;
+    void setSortProtected(bool protect);
+    bool isAutoFilterProtected() const;
+    void setAutoFilterProtected(bool protect);
+    bool isPivotTablesProtected() const;
+    void setPivotTablesProtected(bool protect);
 
     ~Worksheet();
 

--- a/src/xlsx/xlsxworksheet_p.h
+++ b/src/xlsx/xlsxworksheet_p.h
@@ -214,7 +214,6 @@ public:
     XlsxSheetFormatProps sheetFormatProps;
 
     bool windowProtection;
-    bool sheetProtection;
     bool showFormulas;
     bool showGridLines;
     bool showRowColHeaders;
@@ -224,6 +223,25 @@ public:
     bool showRuler;
     bool showOutlineSymbols;
     bool showWhiteSpace;
+
+    // see ECMA-376-1:2016 section 18.3.1.85
+    bool sheetProtection;
+    bool objectsProtection;
+    bool scenariosProtection;
+    bool formatCellsProtection;
+    bool formatColumnsProtection;
+    bool formatRowsProtection;
+    bool insertColumnsProtection;
+    bool insertRowsProtection;
+    bool insertHyperlinksProtection;
+    bool deleteColumnsProtection;
+    bool deleteRowsProtection;
+    bool selectLockedCellsProtection;
+    bool selectUnlockedCellsProtection;
+    bool sortProtection;
+    bool autoFilterProtection;
+    bool pivotTablesProtection;
+
 
     QRegularExpression urlPattern;
 private:

--- a/src/xlsx/xlsxworksheet_p.h
+++ b/src/xlsx/xlsxworksheet_p.h
@@ -214,6 +214,7 @@ public:
     XlsxSheetFormatProps sheetFormatProps;
 
     bool windowProtection;
+    bool sheetProtection;
     bool showFormulas;
     bool showGridLines;
     bool showRowColHeaders;


### PR DESCRIPTION
This adds the `Worksheet::isSheetProtected` and
`Worksheet::setSheetProtected` APIs.

It also correctly writes sheet and cell protection data to the xml
files inside the xlsx archive.

This is based on `ECMA-376-1:2016` sections `18.3.1.84` and
`18.8.33`