### PR TITLE
Fix zero-as-null-pointer-constant warning

### DIFF
--- a/src/xlsx/xlsxcell.h
+++ b/src/xlsx/xlsxcell.h
@@ -67,7 +67,7 @@ private:
     friend class Worksheet;
     friend class WorksheetPrivate;
 
-    Cell(const QVariant &data=QVariant(), CellType type=NumberType, const Format &format=Format(), Worksheet *parent = nullptr);
+    Cell(const QVariant &data=QVariant(), CellType type=NumberType, const Format &format=Format(), Worksheet *parent = Q_NULLPTR);
     Cell(const Cell * const cell);
     CellPrivate * const d_ptr;
 };

--- a/src/xlsx/xlsxcell.h
+++ b/src/xlsx/xlsxcell.h
@@ -67,7 +67,7 @@ private:
     friend class Worksheet;
     friend class WorksheetPrivate;
 
-    Cell(const QVariant &data=QVariant(), CellType type=NumberType, const Format &format=Format(), Worksheet *parent=0);
+    Cell(const QVariant &data=QVariant(), CellType type=NumberType, const Format &format=Format(), Worksheet *parent = nullptr);
     Cell(const Cell * const cell);
     CellPrivate * const d_ptr;
 };

--- a/src/xlsx/xlsxchart.h
+++ b/src/xlsx/xlsxchart.h
@@ -67,7 +67,7 @@ public:
 
     ~Chart();
 
-    void addSeries(const CellRange &range, AbstractSheet *sheet=0);
+    void addSeries(const CellRange &range, AbstractSheet *sheet = nullptr);
     void setChartType(ChartType type);
     void setChartStyle(int id);
 

--- a/src/xlsx/xlsxchart.h
+++ b/src/xlsx/xlsxchart.h
@@ -67,7 +67,7 @@ public:
 
     ~Chart();
 
-    void addSeries(const CellRange &range, AbstractSheet *sheet = nullptr);
+    void addSeries(const CellRange &range, AbstractSheet *sheet = Q_NULLPTR);
     void setChartType(ChartType type);
     void setChartStyle(int id);
 

--- a/src/xlsx/xlsxchartsheet.cpp
+++ b/src/xlsx/xlsxchartsheet.cpp
@@ -37,7 +37,7 @@
 QT_BEGIN_NAMESPACE_XLSX
 
 ChartsheetPrivate::ChartsheetPrivate(Chartsheet *p, Chartsheet::CreateFlag flag)
-    : AbstractSheetPrivate(p, flag), chart(0)
+    : AbstractSheetPrivate(p, flag), chart(nullptr)
 {
 
 }
@@ -87,7 +87,7 @@ Chartsheet *Chartsheet::copy(const QString &distName, int distId) const
     //:Todo
     Q_UNUSED(distName)
     Q_UNUSED(distId)
-    return 0;
+    return nullptr;
 }
 
 /*!

--- a/src/xlsx/xlsxchartsheet.cpp
+++ b/src/xlsx/xlsxchartsheet.cpp
@@ -37,7 +37,7 @@
 QT_BEGIN_NAMESPACE_XLSX
 
 ChartsheetPrivate::ChartsheetPrivate(Chartsheet *p, Chartsheet::CreateFlag flag)
-    : AbstractSheetPrivate(p, flag), chart(nullptr)
+    : AbstractSheetPrivate(p, flag), chart(Q_NULLPTR)
 {
 
 }
@@ -87,7 +87,7 @@ Chartsheet *Chartsheet::copy(const QString &distName, int distId) const
     //:Todo
     Q_UNUSED(distName)
     Q_UNUSED(distId)
-    return nullptr;
+    return Q_NULLPTR;
 }
 
 /*!

--- a/src/xlsx/xlsxcolor.cpp
+++ b/src/xlsx/xlsxcolor.cpp
@@ -122,10 +122,10 @@ QColor XlsxColor::fromARGBString(const QString &c)
 {
     Q_ASSERT(c.length() == 8);
     QColor color;
-    color.setAlpha(c.mid(0, 2).toInt(0, 16));
-    color.setRed(c.mid(2, 2).toInt(0, 16));
-    color.setGreen(c.mid(4, 2).toInt(0, 16));
-    color.setBlue(c.mid(6, 2).toInt(0, 16));
+    color.setAlpha(c.mid(0, 2).toInt(nullptr, 16));
+    color.setRed(c.mid(2, 2).toInt(nullptr, 16));
+    color.setGreen(c.mid(4, 2).toInt(nullptr, 16));
+    color.setBlue(c.mid(6, 2).toInt(nullptr, 16));
     return color;
 }
 

--- a/src/xlsx/xlsxcolor.cpp
+++ b/src/xlsx/xlsxcolor.cpp
@@ -122,10 +122,10 @@ QColor XlsxColor::fromARGBString(const QString &c)
 {
     Q_ASSERT(c.length() == 8);
     QColor color;
-    color.setAlpha(c.mid(0, 2).toInt(nullptr, 16));
-    color.setRed(c.mid(2, 2).toInt(nullptr, 16));
-    color.setGreen(c.mid(4, 2).toInt(nullptr, 16));
-    color.setBlue(c.mid(6, 2).toInt(nullptr, 16));
+    color.setAlpha(c.mid(0, 2).toInt(Q_NULLPTR, 16));
+    color.setRed(c.mid(2, 2).toInt(Q_NULLPTR, 16));
+    color.setGreen(c.mid(4, 2).toInt(Q_NULLPTR, 16));
+    color.setBlue(c.mid(6, 2).toInt(Q_NULLPTR, 16));
     return color;
 }
 

--- a/src/xlsx/xlsxconditionalformatting.h
+++ b/src/xlsx/xlsxconditionalformatting.h
@@ -126,7 +126,7 @@ private:
     friend class Worksheet;
     friend class ::ConditionalFormattingTest;
     bool saveToXml(QXmlStreamWriter &writer) const;
-    bool loadFromXml(QXmlStreamReader &reader, Styles *styles = nullptr);
+    bool loadFromXml(QXmlStreamReader &reader, Styles *styles = Q_NULLPTR);
     QSharedDataPointer<ConditionalFormattingPrivate> d;
 };
 

--- a/src/xlsx/xlsxconditionalformatting.h
+++ b/src/xlsx/xlsxconditionalformatting.h
@@ -126,7 +126,7 @@ private:
     friend class Worksheet;
     friend class ::ConditionalFormattingTest;
     bool saveToXml(QXmlStreamWriter &writer) const;
-    bool loadFromXml(QXmlStreamReader &reader, Styles *styles=0);
+    bool loadFromXml(QXmlStreamReader &reader, Styles *styles = nullptr);
     QSharedDataPointer<ConditionalFormattingPrivate> d;
 };
 

--- a/src/xlsx/xlsxdocument.cpp
+++ b/src/xlsx/xlsxdocument.cpp
@@ -469,7 +469,7 @@ Chart *Document::insertChart(int row, int col, const QSize &size)
 {
     if (Worksheet *sheet = currentWorksheet())
         return sheet->insertChart(row, col, size);
-    return 0;
+    return nullptr;
 }
 
 /*!
@@ -939,7 +939,7 @@ Cell *Document::cellAt(const CellReference &pos) const
 {
     if (Worksheet *sheet = currentWorksheet())
         return sheet->cellAt(pos);
-    return 0;
+    return nullptr;
 }
 
 /*!
@@ -952,7 +952,7 @@ Cell *Document::cellAt(int row, int col) const
 {
     if (Worksheet *sheet = currentWorksheet())
         return sheet->cellAt(row, col);
-    return 0;
+    return nullptr;
 }
 
 /*!
@@ -1132,7 +1132,7 @@ Worksheet *Document::currentWorksheet() const
     if (st && st->sheetType() == AbstractSheet::ST_WorkSheet)
         return static_cast<Worksheet *>(st);
     else
-        return 0;
+        return nullptr;
 }
 
 /*!

--- a/src/xlsx/xlsxdocument.cpp
+++ b/src/xlsx/xlsxdocument.cpp
@@ -469,7 +469,7 @@ Chart *Document::insertChart(int row, int col, const QSize &size)
 {
     if (Worksheet *sheet = currentWorksheet())
         return sheet->insertChart(row, col, size);
-    return nullptr;
+    return Q_NULLPTR;
 }
 
 /*!
@@ -939,7 +939,7 @@ Cell *Document::cellAt(const CellReference &pos) const
 {
     if (Worksheet *sheet = currentWorksheet())
         return sheet->cellAt(pos);
-    return nullptr;
+    return Q_NULLPTR;
 }
 
 /*!
@@ -952,7 +952,7 @@ Cell *Document::cellAt(int row, int col) const
 {
     if (Worksheet *sheet = currentWorksheet())
         return sheet->cellAt(row, col);
-    return nullptr;
+    return Q_NULLPTR;
 }
 
 /*!
@@ -1132,7 +1132,7 @@ Worksheet *Document::currentWorksheet() const
     if (st && st->sheetType() == AbstractSheet::ST_WorkSheet)
         return static_cast<Worksheet *>(st);
     else
-        return nullptr;
+        return Q_NULLPTR;
 }
 
 /*!

--- a/src/xlsx/xlsxdocument.h
+++ b/src/xlsx/xlsxdocument.h
@@ -51,9 +51,9 @@ class Q_XLSX_EXPORT Document : public QObject
     Q_DECLARE_PRIVATE(Document)
 
 public:
-    explicit Document(QObject *parent = 0);
-    Document(const QString &xlsxName, QObject *parent=0);
-    Document(QIODevice *device, QObject *parent=0);
+    explicit Document(QObject *parent = nullptr);
+    Document(const QString &xlsxName, QObject *parent = nullptr);
+    Document(QIODevice *device, QObject *parent = nullptr);
     ~Document();
 
     bool write(const CellReference &cell, const QVariant &value, const Format &format=Format());

--- a/src/xlsx/xlsxdocument.h
+++ b/src/xlsx/xlsxdocument.h
@@ -51,9 +51,9 @@ class Q_XLSX_EXPORT Document : public QObject
     Q_DECLARE_PRIVATE(Document)
 
 public:
-    explicit Document(QObject *parent = nullptr);
-    Document(const QString &xlsxName, QObject *parent = nullptr);
-    Document(QIODevice *device, QObject *parent = nullptr);
+    explicit Document(QObject *parent = Q_NULLPTR);
+    Document(const QString &xlsxName, QObject *parent = Q_NULLPTR);
+    Document(QIODevice *device, QObject *parent = Q_NULLPTR);
     ~Document();
 
     bool write(const CellReference &cell, const QVariant &value, const Format &format=Format());

--- a/src/xlsx/xlsxworkbook.cpp
+++ b/src/xlsx/xlsxworkbook.cpp
@@ -210,7 +210,7 @@ AbstractSheet *Workbook::addSheet(const QString &name, int sheetId, AbstractShee
     Q_D(Workbook);
     if (sheetId > d->last_sheet_id)
         d->last_sheet_id = sheetId;
-    AbstractSheet *sheet = nullptr;
+    AbstractSheet *sheet = Q_NULLPTR;
     if (type == AbstractSheet::ST_WorkSheet) {
         sheet = new Worksheet(name, sheetId, this, F_LoadFromExists);
     } else if (type == AbstractSheet::ST_ChartSheet) {
@@ -230,12 +230,12 @@ AbstractSheet *Workbook::insertSheet(int index, const QString &name, AbstractShe
     QString sheetName = createSafeSheetName(name);
     if(index > d->last_sheet_id){
         //User tries to insert, where no sheet has gone before.
-        return nullptr;
+        return Q_NULLPTR;
     }
     if (!sheetName.isEmpty()) {
         //If user given an already in-used name, we should not continue any more!
         if (d->sheetNames.contains(sheetName))
-            return nullptr;
+            return Q_NULLPTR;
     } else {
         if (type == AbstractSheet::ST_WorkSheet) {
             do {
@@ -249,7 +249,7 @@ AbstractSheet *Workbook::insertSheet(int index, const QString &name, AbstractShe
             } while (d->sheetNames.contains(sheetName));
         } else {
             qWarning("unsupported sheet type.");
-            return nullptr;
+            return Q_NULLPTR;
         }
     }
 
@@ -391,7 +391,7 @@ AbstractSheet *Workbook::sheet(int index) const
 {
     Q_D(const Workbook);
     if (index < 0 || index >= d->sheets.size())
-        return nullptr;
+        return Q_NULLPTR;
     return d->sheets.at(index).data();
 }
 

--- a/src/xlsx/xlsxworkbook.cpp
+++ b/src/xlsx/xlsxworkbook.cpp
@@ -210,7 +210,7 @@ AbstractSheet *Workbook::addSheet(const QString &name, int sheetId, AbstractShee
     Q_D(Workbook);
     if (sheetId > d->last_sheet_id)
         d->last_sheet_id = sheetId;
-    AbstractSheet *sheet=0;
+    AbstractSheet *sheet = nullptr;
     if (type == AbstractSheet::ST_WorkSheet) {
         sheet = new Worksheet(name, sheetId, this, F_LoadFromExists);
     } else if (type == AbstractSheet::ST_ChartSheet) {
@@ -230,12 +230,12 @@ AbstractSheet *Workbook::insertSheet(int index, const QString &name, AbstractShe
     QString sheetName = createSafeSheetName(name);
     if(index > d->last_sheet_id){
         //User tries to insert, where no sheet has gone before.
-        return 0;
+        return nullptr;
     }
     if (!sheetName.isEmpty()) {
         //If user given an already in-used name, we should not continue any more!
         if (d->sheetNames.contains(sheetName))
-            return 0;
+            return nullptr;
     } else {
         if (type == AbstractSheet::ST_WorkSheet) {
             do {
@@ -249,7 +249,7 @@ AbstractSheet *Workbook::insertSheet(int index, const QString &name, AbstractShe
             } while (d->sheetNames.contains(sheetName));
         } else {
             qWarning("unsupported sheet type.");
-            return 0;
+            return nullptr;
         }
     }
 
@@ -391,7 +391,7 @@ AbstractSheet *Workbook::sheet(int index) const
 {
     Q_D(const Workbook);
     if (index < 0 || index >= d->sheets.size())
-        return 0;
+        return nullptr;
     return d->sheets.at(index).data();
 }
 

--- a/src/xlsx/xlsxworksheet.cpp
+++ b/src/xlsx/xlsxworksheet.cpp
@@ -680,7 +680,7 @@ QVariant Worksheet::read(int row, int column) const
 Cell *Worksheet::cellAt(const CellReference &row_column) const
 {
     if (!row_column.isValid())
-        return NULL;
+        return nullptr;
 
     return cellAt(row_column.row(), row_column.column());
 }
@@ -693,9 +693,9 @@ Cell *Worksheet::cellAt(int row, int column) const
 {
     Q_D(const Worksheet);
     if (!d->cellTable.contains(row))
-        return NULL;
+        return nullptr;
     if (!d->cellTable[row].contains(column))
-        return NULL;
+        return nullptr;
 
     return d->cellTable[row][column].data();
 }

--- a/src/xlsx/xlsxworksheet.cpp
+++ b/src/xlsx/xlsxworksheet.cpp
@@ -680,7 +680,7 @@ QVariant Worksheet::read(int row, int column) const
 Cell *Worksheet::cellAt(const CellReference &row_column) const
 {
     if (!row_column.isValid())
-        return nullptr;
+        return Q_NULLPTR;
 
     return cellAt(row_column.row(), row_column.column());
 }
@@ -693,9 +693,9 @@ Cell *Worksheet::cellAt(int row, int column) const
 {
     Q_D(const Worksheet);
     if (!d->cellTable.contains(row))
-        return nullptr;
+        return Q_NULLPTR;
     if (!d->cellTable[row].contains(column))
-        return nullptr;
+        return Q_NULLPTR;
 
     return d->cellTable[row][column].data();
 }


### PR DESCRIPTION
This PR simply replace `0` or `NULL` by `nullptr`. It allow compiling the code with the following configuration:

```
QMAKE_CXXFLAGS += -Werror -Wzero-as-null-pointer-constant
``` 