### PR TITLE
Use QString::asprintf() instead of sprintf()

### DIFF
--- a/src/xlsx/xlsxcolor.cpp
+++ b/src/xlsx/xlsxcolor.cpp
@@ -131,9 +131,7 @@ QColor XlsxColor::fromARGBString(const QString &c)
 
 QString XlsxColor::toARGBString(const QColor &c)
 {
-    QString color;
-    color.sprintf("%02X%02X%02X%02X", c.alpha(), c.red(), c.green(), c.blue());
-    return color;
+    return QString::asprintf("%02X%02X%02X%02X", c.alpha(), c.red(), c.green(), c.blue());
 }
 
 #if !defined(QT_NO_DATASTREAM)


### PR DESCRIPTION
sprintf() causes redudant allocations and therefore got deprecated.